### PR TITLE
testing pull with a small change to cloudbiolinux.org (gh-pages branch)

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,6 +103,8 @@ new TWTR.Widget({
             <li class="inner"><a href="https://s3.amazonaws.com/cloudbiolinux/cbl_ubuntu_11_4_32_20110628.box">Ubuntu 11.04 32bit (29 June 2011)</a>
             </br><a href="https://s3.amazonaws.com/cloudbiolinux/cbl_debian32_20110427.box">Debian squeeze 32bit (27 April 2011)</a>
             </li>
+            <li class="inner">Information on how to import Cloud BioLinux images in VirtualBox can be found <a href="http://www.virtualbox.org/manual/ch01.html#ovf">here</a>
+            </li>
           </ul>
           <li>Indexed genome builds for aligners such as <a href="http://bowtie-bio.sourceforge.net/">Bowtie</a>, <a href="http://bio-bwa.sourceforge.net/">BWA</a> and <a href="http://www.novocraft.com/">Novoalign</a> in the <a href="http://s3.amazonaws.com/biodata">biodata S3 bucket</a>. An <a href="https://github.com/chapmanb/bcbb/blob/master/ec2/biolinux/data_fabfile.py">automated script</a> pulls the requested genomes and aligner indexes to an Amazon machine or your local computer; integration with Galaxy is also provided.</li>
         </ul>


### PR DESCRIPTION
I will be linking through the site VirtualBox Appliances on S3 made from the Vagrant boxes. Appliances are easier to import for end-users (through File->Import on the Virtualbox GUI) compared to the Vagrant boxes which need command line work, and I would like to have the Appliances available for the paper update.

For now, I am just testing the website update with a small pull request.
