### PR TITLE
python install directory

### DIFF
--- a/cloudbio/custom/shared.py
+++ b/cloudbio/custom/shared.py
@@ -198,7 +198,7 @@ def _java_install(pname, version, url, env, install_fn=None):
 
 def _python_make(env):
     run("python%s setup.py build" % env.python_version_ext)
-    env.safe_sudo("python%s setup.py install --skip-build --prefix '%s'" % (env.python_version_ext, env.system_install))
+    env.safe_sudo("python%s setup.py install --skip-build --prefix '%s'" % (env.python_version_ext, env.python_install))
     for clean in ["dist", "build", "lib/*.egg-info"]:
         env.safe_sudo("rm -rf %s" % clean)
 

--- a/config/fabricrc.txt
+++ b/config/fabricrc.txt
@@ -25,6 +25,7 @@ is_ec2_image = false
 
 # Global installation directory for packages and standard programs
 system_install = /usr
+python_install = /usr/local
 
 # Local install directory for versioned software that will not
 # be included in the path by default


### PR DESCRIPTION
this patch changes the default install directory for "custom" python packages from

```
/usr/lib/python2.7/site-packages
```

to 

```
/usr/local/lib/python2.7/dist-packages
```

The former directory does not exist and is not part of pythonpath on ubuntu 12.04
