### PR TITLE
Implement mechanism to supply user data defaults to CloudMan.

### DIFF
--- a/cloudbio/cloudman.py
+++ b/cloudbio/cloudman.py
@@ -22,7 +22,7 @@ from cloudbio.galaxy import _setup_users
 from cloudbio.flavor.config import get_config_file
 from cloudbio.package.shared import _yaml_to_packages
 from cloudbio.custom.shared import (_make_tmp_dir, _write_to_file, _get_install,
-                                    _configure_make,_if_not_installed)
+                                    _configure_make, _if_not_installed, _setup_conf_file)
 from cloudbio.package.deb import (_apt_packages, _setup_apt_automation)
 
 MI_REPO_ROOT_URL = "https://bitbucket.org/afgane/mi-deployment/raw/tip"
@@ -97,6 +97,11 @@ def _configure_ec2_autorun(env, use_repo_autorun=False):
     cloudman_boot_file = 'cloudman.conf'
     remote_file = '/etc/init/%s' % cloudman_boot_file
     _write_to_file(cm_upstart % (remote, os.path.splitext(remote)[0]), remote_file, mode=0644)
+    # Setup default image user data (if configured by image_user_data_path or
+    # image_user_data_template_path). This specifies defaults for CloudMan when
+    # used with resulting image, normal userdata supplied by user will override
+    # these defaults.
+    _setup_conf_file(env, os.path.join(env.install_dir, "bin", "IMAGE_USER_DATA"), "image_user_data", default_source="image_user_data")
     env.logger.debug("Done configuring CloudMan ec2_autorun")
 
 

--- a/cloudbio/custom/shared.py
+++ b/cloudbio/custom/shared.py
@@ -227,7 +227,9 @@ def _python_make(env):
 
 
 def _get_installed_file(env, local_file):
-    path = os.path.join('installed_files', local_file)
+    installed_files_dir = \
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "installed_files")
+    path = os.path.join(installed_files_dir, local_file)
     if not os.path.exists(path):
         # If using cloudbiolinux as a library, this won't be available,
         # download the file from github instead

--- a/installed_files/image_user_data
+++ b/installed_files/image_user_data
@@ -1,0 +1,3 @@
+# YAML properties placed in this file will act as defaults
+# for CloudMan user data. User supplied data at launch time 
+# will override these properties.


### PR DESCRIPTION
This will allow for image specific CloudMan options (e.g. paths or default_bucket_url) to specified without requiring every user to specify these parameters via user data at launch time. Values specified by user at launch/runtime will take precedence.

These image specific parameters are specified as a file. By default installed_files/image_user_data will be used. Image specific properties can be added directly to this file or a completely new file may be specified by setting image_user_data_path or image_user_data_template_path in fabricrc.

Submitting this as a pull request because it changes CloudMan's behavior somewhat and I would like to provide the opportunity for comment. I think as more people build custom images this will become an important feature so I would be happy to adjust things as you guys see fit. I will merge this soon unless there are objections. 
