### PR TITLE
Sed commands in data_fabfile.py

### DIFF
--- a/cloudbio/biodata/genomes.py
+++ b/cloudbio/biodata/genomes.py
@@ -118,10 +118,11 @@ class NCBIRest(_DownloadHelper):
             for ref in self._refs:
                 run("wget %s" % (self._base_url % ref))
                 run("ls -l")
-                run("sed -rie .bak '/1/ s/^>.*$/>%s/g' %s.fasta" % (ref,
-                    ref))
+                # sed fails in Linux
+                #run("sed -rie .bak '/1/ s/^>.*$/>%s/g' %s.fasta" % (ref,
+                #    ref))
                 # sed in Fabric does not cd properly?
-                #sed('%s.fasta' % ref, '^>.*$', '>%s' % ref, '1')
+                sed('%s.fasta' % ref, '^>.*$', '>%s' % ref, '1')
             tmp_file = genome_file.replace(".fa", ".txt")
             run("cat *.fasta > %s" % tmp_file)
             run("rm -f *.fasta")

--- a/config/biodata.yaml
+++ b/config/biodata.yaml
@@ -43,7 +43,7 @@ genomes:
 #    mask: https://s3.amazonaws.com/chapmanb/xprize/GRCh37-NA12878-xprize-fosmid.bed
 
 # Global set of indexes to include for each genome.
-# Available choices are in GENOMES_INDEXES_SUPPORTED in data_fabfile.py
+# Available choices are in GENOMES_INDEXES_SUPPORTED in cloudbio/biodata/genomes.py
 genome_indexes:
   - bowtie
   - bwa


### PR DESCRIPTION
The following sed command does not execute in a regular bash shell:

```
$ sed -rie .bak '/1/ s/^>.*$/>foo/g' foo.fasta
sed: -e expression #1, char 1: unknown command: `.'
```

On the other hand, the Fabric counterpart works without any issues, as opposed to what's stated in the comment:

```
# sed in Fabric does not cd properly?
```
