### PR TITLE
UCSCGenome similar crash on dl_name attribute

### DIFF
--- a/cloudbio/biodata/genomes.py
+++ b/cloudbio/biodata/genomes.py
@@ -137,7 +137,7 @@ class EnsemblGenome(_DownloadHelper):
     caenorhabditis_elegans/dna/Caenorhabditis_elegans.WS200.56.dna.toplevel.fa.gz
     """
     def __init__(self, ensembl_section, release_number, release2, organism,
-            name, convert_to_ucsc=False):
+            name, convert_to_ucsc=False, dl_name = None):
         _DownloadHelper.__init__(self)
         self.data_source = "Ensembl"
         if ensembl_section == "standard":
@@ -150,6 +150,7 @@ class EnsemblGenome(_DownloadHelper):
         self._get_file = "%s.%s%s.dna.toplevel.fa.gz" % (organism, name,
                 release2)
         self._name = name
+        self.dl_name = dl_name if dl_name is not None else name
         self._convert_to_ucsc = convert_to_ucsc
 
     def download(self, seq_dir):


### PR DESCRIPTION
```
[biologin] run: mkdir -p roman/genomes/Dmelanogaster/dm3/variation
Traceback (most recent call last):
  File "roman/.virtualenvs/py2.7/lib/python2.7/site-packages/fabric/main.py", line 736, in main
    *args, **kwargs
  File "roman/.virtualenvs/py2.7/lib/python2.7/site-packages/fabric/tasks.py", line 314, in execute
    multiprocessing
  File "roman/.virtualenvs/py2.7/lib/python2.7/site-packages/fabric/tasks.py", line 211, in _execute
    return task.run(*args, **kwargs)
  File "roman/.virtualenvs/py2.7/lib/python2.7/site-packages/fabric/tasks.py", line 121, in run
    return self.wrapped(*args, **kwargs) 
  File "roman/dev/cloudbiolinux/data_fabfile.py", line 61, in install_data
    genomes.install_data(config_source)  
  File "roman/dev/cloudbiolinux/cloudbio/biodata/genomes.py", line 245, in install_data
    _install_additional_data(genomes, genome_indexes, config)
  File "roman/dev/cloudbiolinux/cloudbio/biodata/genomes.py", line 279, in _install_additional_data
    download_dbsnp(genomes, BROAD_BUNDLE_VERSION, DBSNP_VERSION)
  File "roman/dev/cloudbiolinux/cloudbio/biodata/dbsnp.py", line 34, in download_dbsnp
    _download_broad_bundle(manager.dl_name, bundle_version, dl_name, dl_ext)
AttributeError: UCSCGenome instance has no attribute 'dl_name'
Disconnecting from biologin... done.
```
