### PR TITLE
Respect env.system_install when installing python tools

### DIFF
--- a/cloudbio/custom/shared.py
+++ b/cloudbio/custom/shared.py
@@ -242,7 +242,8 @@ def _pip_cmd(env):
     raise ValueError("Could not find pip installer from: %s" % to_check)
 
 def _python_make(env):
-    env.safe_sudo("%s install --upgrade ." % _pip_cmd(env))
+    env.safe_sudo('%s install --upgrade --install-option="--prefix=%s" .' %
+                 (_pip_cmd(env), env.system_install))
     for clean in ["dist", "build", "lib/*.egg-info"]:
         env.safe_sudo("rm -rf %s" % clean)
 


### PR DESCRIPTION
Otherwise python tools get installed in /usr/local/bin; I'm just not sure if there are cases where this is not going to work?
