### PR TITLE
Fix for name or service unknown

### DIFF
--- a/utils/s3_multipart_upload.py
+++ b/utils/s3_multipart_upload.py
@@ -31,12 +31,14 @@ from optparse import OptionParser
 import rfc822
 
 import boto
+from boto.s3.connection import S3Connection
 
 def main(transfer_file, bucket_name, s3_key_name=None, use_rr=True,
          make_public=True, cores=None):
     if s3_key_name is None:
         s3_key_name = os.path.basename(transfer_file)
-    conn = boto.connect_s3()
+    calling_format=boto.s3.connection.OrdinaryCallingFormat()
+    conn = boto.connect_s3(calling_format=calling_format)
     bucket = conn.lookup(bucket_name)
     if bucket is None:
         bucket = conn.create_bucket(bucket_name)


### PR DESCRIPTION
A connection format must be specified. Otherwise, I have been receiving a name or service unknown error.

```
Traceback (most recent call last):
File "./my-python-script.py", line 111, in <module>
bucket = conn.create_bucket(bucket_name)
File "/usr/lib/python2.6/site-packages/boto/s3/connection.py", line 434, in create_bucket
data=data)
File "/usr/lib/python2.6/site-packages/boto/s3/connection.py", line 470, in make_request
override_num_retries=override_num_retries)
File "/usr/lib/python2.6/site-packages/boto/connection.py", line 913, in make_request
return self._mexe(http_request, sender, override_num_retries)
File "/usr/lib/python2.6/site-packages/boto/connection.py", line 859, in _mexe
raise e
socket.gaierror: [Errno -2] Name or service not known
```
