### PR TITLE
Fix flavor selection

### DIFF
--- a/cloudbio/utils.py
+++ b/cloudbio/utils.py
@@ -115,11 +115,11 @@ def _setup_flavor(env, flavor):
             "Did not find directory {0} for flavor {1}".format(flavor_dir, flavor)
         env.flavor_dir = flavor_dir
         # Load python customizations to base configuration if present
-        py_flavor = "{0}flavor".format(os.path.split(os.path.realpath(flavor_dir)))
+        py_flavor = "{0}flavor".format(os.path.split(os.path.realpath(flavor_dir))[1])
         flavor_custom_py = os.path.join(flavor_dir, "{0}.py".format(py_flavor))
         if os.path.exists(flavor_custom_py):
             sys.path.append(flavor_dir)
-            mod = __import__(flavor_dir, fromlist=[py_flavor])
+            mod = __import__(py_flavor, fromlist=[py_flavor])
     env.logger.info("This is a %s" % env.flavor.name)
 
 


### PR DESCRIPTION
Hi, I found that the post_install in our gvl flavor was never getting run. I found that the _setup_flavor code in cloudbio/utils.py was always diverting to the base flavor. I found that it could not find the flavor.py file. 

The code was using os.path.split to get the prefix of the filename by using the flavor name (which was the dir name of the flavor). 
        py_flavor = "{0}flavor".format(os.path.split(os.path.realpath(flavor_dir)))

However, os.path.split returns an array of 2 items, being the full path, and the filename (or last dir name in this case) itself. So, when the array was toString'ed, it was making a nonsense filename to look up.
This was fixed by selecting the last component of os.path.split only.
        py_flavor = "{0}flavor".format(os.path.split(os.path.realpath(flavor_dir))[1])

Another problem after this was saying **import** doesn't work on filenames. because the first parameter was the dir name.
      mod = **import**(flavor_dir, fromlist=[py_flavor])

This was fixed to be the module name instead:
            mod = **import**(py_flavor, fromlist=[py_flavor])

Now it was correctly loading the given flavor, used for post_install.

Looks like this issue come in 8 months ago
