### PR TITLE
End need to specify or change distribution and dist_name in most cases.

### DIFF
--- a/config/fabricrc.txt
+++ b/config/fabricrc.txt
@@ -6,9 +6,16 @@
 #   fab -f data_fabfile.py -H your_machine -c your_fabricrc.txt install_data_s3:your_biodata.yaml
 
 # -- Details about the operating system
+
+## If target machine is Ubuntu or CentOS, the following defaults should allow CloudBioLinux to 
+## automatically determine the correct settings. For other operating systems (e.g. Debian or ScientificLinux)
+## please override distribution (and dist_name in case of Debian).
+distribution = __auto__
+dist_name = __auto__
+
 ## Ubuntu
-distribution = ubuntu
-dist_name = quantal
+#distribution = ubuntu
+#dist_name = quantal
 ## Centos
 #distribution = centos
 ## Debian


### PR DESCRIPTION
Seems to work right now for Ubuntu or CentOS. SL and Debian would still need to specify these, but they would anyway so this is not a step backwards (anyone have a test environment to fill out the rest of _determine_distribution)?

Submitting this as a pull request because the changeset that added the dist_name check broke a lot of stuff I didn't totally understand, is this going to break to anything?
