### PR TITLE
Fix some issues in installation of linux homebrew

### DIFF
--- a/cloudbio/package/brew.py
+++ b/cloudbio/package/brew.py
@@ -188,8 +188,6 @@ def _install_brew_baseline(env, brew_cmd, ipkgs, packages):
                     brew_cmd=brew_cmd)).split("\n")[-1].rstrip())
             if has_bcftools:
                 env.safe_run("{brew_cmd} uninstall {pkg}".format(brew_cmd=brew_cmd, pkg="samtools"))
-            if has_bcftools:
-                env.safe_run("{brew_cmd} uninstall {pkg}".format(brew_cmd=brew_cmd, pkg="samtools"))
     cpanm_cmd = os.path.join(os.path.dirname(brew_cmd), "cpanm")
     for perl_lib in ["Statistics::Descriptive"]:
         env.safe_run("%s -i --notest --local-lib=%s '%s'" % (cpanm_cmd, env.system_install, perl_lib))


### PR DESCRIPTION
When the installation of hombrew main frame finished, I met an exception as:

``` bash
[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew tap homebrew/science
[vagrant@127.0.0.1:2222] out: Cloning into '/usr/local/Library/Taps/homebrew-science'...
[vagrant@127.0.0.1:2222] out: remote: Reusing existing pack: 3579, done.
[vagrant@127.0.0.1:2222] out: remote: Counting objects: 41, done.
[vagrant@127.0.0.1:2222] out: remote: Compressing objects: 100% (41/41), done.
[vagrant@127.0.0.1:2222] out: remote: Total 3620 (delta 13), reused 4 (delta 0)
[vagrant@127.0.0.1:2222] out: Receiving objects: 100% (3620/3620), 928.75 KiB, done.
[vagrant@127.0.0.1:2222] out: Resolving deltas: 100% (1656/1656), done.
[vagrant@127.0.0.1:2222] out: Tapped 239 formula

[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew tap chapmanb/cbl
[vagrant@127.0.0.1:2222] out: Cloning into '/usr/local/Library/Taps/chapmanb-cbl'...
[vagrant@127.0.0.1:2222] out: remote: Reusing existing pack: 51, done.
[vagrant@127.0.0.1:2222] out: remote: Total 51 (delta 0), reused 0 (delta 0)
[vagrant@127.0.0.1:2222] out: Unpacking objects: 100% (51/51), done.
[vagrant@127.0.0.1:2222] out: Warning: Could not tap chapmanb/cbl/samtools over homebrew/science/samtools
[vagrant@127.0.0.1:2222] out: Warning: Could not tap chapmanb/cbl/htslib over homebrew/science/htslib
[vagrant@127.0.0.1:2222] out: Tapped 7 formula

[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew tap --repair
[vagrant@127.0.0.1:2222] out: Pruned 0 dead formula
[vagrant@127.0.0.1:2222] out: Warning: Could not tap chapmanb/cbl/samtools over homebrew/science/samtools
[vagrant@127.0.0.1:2222] out: Warning: Could not tap chapmanb/cbl/htslib over homebrew/science/htslib
[vagrant@127.0.0.1:2222] out: Tapped 244 formula

[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew outdated
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/fabric/main.py", line 674, in main
    *args, **kwargs
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 229, in execute
    task.run(*args, **new_kwargs)
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 105, in run
    return self.wrapped(*args, **kwargs)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 74, in install_biolinux
    _perform_install(target, flavor)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 113, in _perform_install
    install_brew(flavor=flavor)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 300, in install_brew
    brew.install_packages(env, to_install=pkg_install)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/cloudbio/package/brew.py", line 36, in install_packages
    "current": _get_current_pkgs(env, brew_cmd)}
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/cloudbio/package/brew.py", line 58, in _get_current_pkgs
    pkg, version = line.rstrip().split()
ValueError: too many values to unpack
Disconnecting from vagrant@127.0.0.1:2222... done.
```

And I print the content of 'line' variable, it is:

``` bash
Error: No such file or directory - /usr/local/Cellar
```

It looks like before first start "brew doctor", Cellar folder need to be created.

Another problem is that when I run at the step of checking the installation of samtools in homebrew or cbl,  an exception was met:

``` bash
[vagrant@127.0.0.1:2222] run: export CC=${CC:-`which gcc`} && export CXX=${CXX:-`which g++`} && export PERL5LIB=/usr/local/lib/perl5:${PERL5LIB} && /usr/local/bin/brew install --env=inherit expat
[vagrant@127.0.0.1:2222] out: ==> Downloading http://downloads.sourceforge.net/project/expat/expat/2.1.0/expat-2.1.0.tar.gz
[vagrant@127.0.0.1:2222] out: ######################################################################## 100.0%
[vagrant@127.0.0.1:2222] out: ==> ./configure --prefix=/usr/local/Cellar/expat/2.1.0 --mandir=/usr/local/Cellar/expat/2.1.0/share/man
[vagrant@127.0.0.1:2222] out: ==> make install
[vagrant@127.0.0.1:2222] out: ==> Caveats
[vagrant@127.0.0.1:2222] out: Note that OS X has Expat 1.5 installed in /usr already.
[vagrant@127.0.0.1:2222] out: ==> Summary
[vagrant@127.0.0.1:2222] out: /usr/local/Cellar/expat/2.1.0: 11 files, 504K, built in 25 seconds

[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew link --overwrite expat
[vagrant@127.0.0.1:2222] out: Warning: Already linked: /usr/local/Cellar/expat/2.1.0
[vagrant@127.0.0.1:2222] out: To relink: brew unlink expat && brew link expat

[vagrant@127.0.0.1:2222] run: /usr/local/bin/brew list samtools | grep -c bcftools
[vagrant@127.0.0.1:2222] out: Error: No such keg: /usr/local/Cellar/samtools
[vagrant@127.0.0.1:2222] out: 0


Warning: run() encountered an error (return code 1) while executing '/usr/local/bin/brew list samtools | grep -c bcftools'

Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/fabric/main.py", line 674, in main
    *args, **kwargs
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 229, in execute
    task.run(*args, **new_kwargs)
  File "/usr/lib/python2.7/dist-packages/fabric/tasks.py", line 105, in run
    return self.wrapped(*args, **kwargs)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 74, in install_biolinux
    _perform_install(target, flavor)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 113, in _perform_install
    install_brew(flavor=flavor)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/fabfile.py", line 300, in install_brew
    brew.install_packages(env, to_install=pkg_install)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/cloudbio/package/brew.py", line 37, in install_packages
    _install_brew_baseline(env, brew_cmd, ipkgs, packages)
  File "/home/nshao/opt/source/cloudbio/cloudbiolinux/cloudbio/package/brew.py", line 184, in _install_brew_baseline
    brew_cmd=brew_cmd)))
ValueError: invalid literal for int() with base 10: 'Error: No such keg: /usr/local/Cellar/samtools\r\n0'
Disconnecting from vagrant@127.0.0.1:2222... done.
```

The output of `/usr/local/bin/brew list samtools | grep -c bcftools` just resulted in error warning and result together:

``` bash
Error: No such keg: /usr/local/Cellar/samtools
0
```

And broke the pipeline.

std.out and std.err just mixed together and break the pipeline.
