### PR TITLE
If passed as number mode gets converted to decimal, should be string

### DIFF
--- a/cloudbio/custom/bio_proteomics_wine.py
+++ b/cloudbio/custom/bio_proteomics_wine.py
@@ -66,7 +66,7 @@ wine %s "$@"
 """ % to
     bin_dir = _get_bin_dir(env)
     dest = "%s/%s" % (bin_dir, basename)
-    _write_to_file(contents, dest, 0755)
+    _write_to_file(contents, dest, '0755')
 
 
 def _conf_wine(env):


### PR DESCRIPTION
On Ubuntu 12.04 mode gets converted to decimal if not passed as string.
