### PR TITLE
Revise Trinity installation

### DIFF
--- a/cloudbio/custom/bio_nextgen.py
+++ b/cloudbio/custom/bio_nextgen.py
@@ -631,11 +631,11 @@ def install_ray(env):
 
 def install_trinity(env):
     """Efficient and robust de novo reconstruction of transcriptomes from RNA-seq data.
-    http://trinityrnaseq.sourceforge.net/
+    http://trinityrnaseq.github.io/
     """
-    version = "r2012-10-05"
-    url = "http://downloads.sourceforge.net/project/trinityrnaseq/" \
-          "trinityrnaseq_%s.tgz" % version
+    version = "v2.0.2"
+    url = "https://github.com/trinityrnaseq/trinityrnaseq/archive/" \
+          "%s.tar.gz" % version
     def _remove_werror(env):
         env.safe_sed("trinity-plugins/jellyfish/Makefile.in", " -Werror", "")
     _get_install_local(url, env, _make_copy(),

--- a/cloudbio/custom/bio_nextgen.py
+++ b/cloudbio/custom/bio_nextgen.py
@@ -633,13 +633,12 @@ def install_trinity(env):
     """Efficient and robust de novo reconstruction of transcriptomes from RNA-seq data.
     http://trinityrnaseq.github.io/
     """
-    version = "v2.0.2"
+    version = "2.0.2"
     url = "https://github.com/trinityrnaseq/trinityrnaseq/archive/" \
-          "%s.tar.gz" % version
-    def _remove_werror(env):
-        env.safe_sed("trinity-plugins/jellyfish/Makefile.in", " -Werror", "")
+          "v%s.tar.gz" % version
+    dir_name = "trinityrnaseq-%s" % version
     _get_install_local(url, env, _make_copy(),
-                       post_unpack_fn=_remove_werror)
+                       dir_name=dir_name)
 
 def install_cortex_var(env):
     """De novo genome assembly and variation analysis from sequence data.


### PR DESCRIPTION
The [old site](http://trinityrnaseq.sourceforge.net/) says:
> The Trinity RNA-Seq website has moved to http://trinityrnaseq.github.io

Trinity also is bumped to a new version, with slightly altered installation procedure.

