### PR TITLE
Don't check Github certificates

### DIFF
--- a/ggd-recipes/GRCh37/GA4GH_problem_regions.yaml
+++ b/ggd-recipes/GRCh37/GA4GH_problem_regions.yaml
@@ -24,8 +24,8 @@ recipe:
         wget -O - http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeDacMapabilityConsensusExcludable.bed.gz | gunzip -c | sed "s/^chrM/MT/g" | sed "s/^chr//g" > $encode/wgEncodeDacMapabilityConsensusExcludable.bed
         repeats=coverage/problem_regions/repeats
         mkdir -p $repeats
-        wget -O - https://raw.githubusercontent.com/chapmanb/delly/master/human.hg19.excl.tsv | grep ^chr > $repeats/sv_repeat_telomere_centromere.bed
-        wget -O - https://github.com/lh3/varcmp/raw/master/scripts/LCR-hs37d5.bed.gz | gunzip -c  | bgzip -c > $repeats/LCR.bed.gz
+        wget --no-check-certificate -O - https://raw.githubusercontent.com/chapmanb/delly/master/human.hg19.excl.tsv | grep ^chr > $repeats/sv_repeat_telomere_centromere.bed
+        wget --no-check-certificate -O - https://github.com/lh3/varcmp/raw/master/scripts/LCR-hs37d5.bed.gz | gunzip -c  | bgzip -c > $repeats/LCR.bed.gz
         tabix -p vcf -f $repeats/LCR.bed.gz
     recipe_outfiles:
       - coverage/problem_regions/GA4GH/README.md

--- a/ggd-recipes/hg19/GA4GH_problem_regions.yaml
+++ b/ggd-recipes/hg19/GA4GH_problem_regions.yaml
@@ -19,8 +19,8 @@ recipe:
         wget -O - http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeDacMapabilityConsensusExcludable.bed.gz | gunzip -c > $encode/wgEncodeDacMapabilityConsensusExcludable.bed
         repeats=coverage/problem_regions/repeats
         mkdir -p $repeats
-        wget -O - https://raw.githubusercontent.com/chapmanb/delly/master/human.hg19.excl.tsv | grep -v ^chr > $repeats/sv_repeat_telomere_centromere.bed
-        wget -O - https://github.com/lh3/varcmp/raw/master/scripts/LCR-hs37d5.bed.gz | gunzip -c | grep -v ^GL | grep -v ^NC | grep -v ^hs | sed 's/^/chr/' | bgzip -c > $repeats/LCR.bed.gz
+        wget --no-check-certificate -O - https://raw.githubusercontent.com/chapmanb/delly/master/human.hg19.excl.tsv | grep -v ^chr > $repeats/sv_repeat_telomere_centromere.bed
+        wget --no-check-certificate -O - https://github.com/lh3/varcmp/raw/master/scripts/LCR-hs37d5.bed.gz | gunzip -c | grep -v ^GL | grep -v ^NC | grep -v ^hs | sed 's/^/chr/' | bgzip -c > $repeats/LCR.bed.gz
         tabix -p vcf -f $repeats/LCR.bed.gz
     recipe_outfiles:
       - coverage/problem_regions/GA4GH/README.md


### PR DESCRIPTION
Updating bcbio and hit this error:
```
Running GGD recipe: GA4GH-problem-regions
Traceback (most recent call last):
  File "/packages/bcbio/v0.8.8/bin/bcbio_nextgen.py", line 207, in <module>
    install.upgrade_bcbio(kwargs["args"])
  File "/packages/bcbio/v0.8.8/anaconda/lib/python2.7/site-packages/bcbio/install.py", line 100, in upgrade_bcbio
    upgrade_bcbio_data(args, REMOTES)
  File "/packages/bcbio/v0.8.8/anaconda/lib/python2.7/site-packages/bcbio/install.py", line 259, in upgrade_bcbio_data
    cbl_deploy.deploy(s)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/deploy/__init__.py", line 65, in deploy
    _setup_vm(options, vm_launcher, actions)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/deploy/__init__.py", line 110, in _setup_vm
    configure_instance(options, actions)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/deploy/__init__.py", line 268, in configure_instance
    setup_biodata(options)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/deploy/__init__.py", line 250, in setup_biodata
    install_proc(options["genomes"], ["ggd", "s3", "raw"])
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/biodata/genomes.py", line 350, in install_data
    _prep_genomes(env, genomes, genome_indexes, ready_approaches)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/biodata/genomes.py", line 477, in _prep_genomes
    retrieve_fn(env, manager, gid, idx)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/biodata/genomes.py", line 767, in _install_with_ggd
    ggd.install_recipe(env.cwd, recipe_file)
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/biodata/ggd.py", line 30, in install_recipe
    recipe["recipe"]["full"]["recipe_type"])
  File "/packages/bcbio/v0.8.8/tmpbcbio-install/cloudbiolinux/cloudbio/biodata/ggd.py", line 62, in _run_recipe
    subprocess.check_output(["bash", run_file])
  File "/packages/bcbio/v0.8.8/anaconda/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command '['bash', '/packages/bcbio/v0.8.8/genomes/Hsapiens/GRCh37/txtmp/ggd-run.sh']' returned non-zero exit status 1
```

Running `ggd-run.sh` threw a github certificate error.
```
mdeboth@baldur:/packages/bcbio/v0.8.8/bash /packages/bcbio/v0.8.8/genomes/Hsapiens/GRCh37/txtmp/ggd-run.sh --2015-10-29 13:31:13--  http://bcbio_nextgen.s3.amazonaws.com/GA4GH_problem_regions.zip
Resolving bcbio_nextgen.s3.amazonaws.com... 54.231.98.184
Connecting to bcbio_nextgen.s3.amazonaws.com|54.231.98.184|:80... connected.
HTTP request sent, awaiting response... 416 Requested Range Not Satisfiable

    The file is already fully retrieved; nothing to do.

Archive:  GA4GH_problem_regions.zip
  inflating: README.md
  inflating: bad_promoter.bed
  inflating: gc15.bed
  inflating: gc15to20.bed
  inflating: gc20to25.bed
  inflating: gc25to30.bed
  inflating: gc65to70.bed
  inflating: gc70to75.bed
  inflating: gc75to80.bed
  inflating: gc80to85.bed
  inflating: gc85.bed
  inflating: heng_um75-hs37d5.bed
  inflating: low_complexity_51to200bp.bed
  inflating: low_complexity_gt200bp.bed
  inflating: low_complexity_lt51bp.bed
  inflating: self_chain.bed
--2015-10-29 13:31:57--  http://hgdownload.cse.ucsc.edu/goldenPath/hg19/encodeDCC/wgEncodeMapability/wgEncodeDacMapabilityConsensusExcludable.bed.gz
Resolving hgdownload.cse.ucsc.edu... 128.114.119.163
Connecting to hgdownload.cse.ucsc.edu|128.114.119.163|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4731 (4.6K) [application/x-gzip]
Saving to: “STDOUT”

100%[=============================================================================================>] 4,731       --.-K/s   in 0s

2015-10-29 13:31:57 (276 MB/s) - written to stdout [4731/4731]

--2015-10-29 13:31:57--  https://raw.githubusercontent.com/chapmanb/delly/master/human.hg19.excl.tsv
Resolving raw.githubusercontent.com... 199.27.79.133
Connecting to raw.githubusercontent.com|199.27.79.133|:443... connected.
ERROR: certificate common name “www.github.com” doesn’t match requested host name “raw.githubusercontent.com”.
To connect to raw.githubusercontent.com insecurely, use ‘--no-check-certificate’.
```

Adding `--no-check-certifcate` to the two Github downloads fixed the problem for me. Not sure I'm doing this pull request correctly, so please ignore if there's a more elegant solution.