### PR TITLE
Increase robustness of unpacking in secure containers

### DIFF
--- a/ggd-recipes/GRCh37/transcripts.yaml
+++ b/ggd-recipes/GRCh37/transcripts.yaml
@@ -12,7 +12,7 @@ recipe:
       - |
         baseurl=https://s3.amazonaws.com/biodata/annotation/GRCh37-rnaseq-2015-12-01.tar.xz
         wget -c -N $baseurl
-        xz -dc *-rnaseq-*.tar.xz | tar -xpf -
+        xz -dc *-rnaseq-*.tar.xz | tar --no-same-owner -xpf -
         mv */rnaseq-* rnaseq
     recipe_outfiles:
       - rnaseq/kallisto


### PR DESCRIPTION
Adding the `--no-same-owner` option to the unpacking command to avoid permission errors like that below.  This can occur in more secure LXC or Docker setups where user ID namespaces differ from the host.

```
tar: GRCh37/rnaseq-2015-12-01/ref-transcripts.genePred: Cannot change ownership to uid 57074, gid 402011: Invalid argument
tar: GRCh37/rnaseq-2015-12-01/tophat/GRCh37_transcriptome.1.bt2: Cannot change ownership to uid 57074, gid 402011: Invalid argument
...
```