### PR TITLE
Add refGene. Use latest dbSNP and ClinVar. Add ClinVar for hg19 and GRCh37.

### DIFF
--- a/config/biodata.yaml
+++ b/config/biodata.yaml
@@ -20,14 +20,14 @@ genomes:
   - dbkey: hg19
     name: Human (hg19)
     annotations: [mirbase, GA4GH_problem_regions, MIG, prioritize, dbsnp, hapmap, 1000g_omni_snps, 1000g_snps,
-                  mills_indels, cosmic, ancestral, qsignature, ACMG56_genes, transcripts]
+                  mills_indels, cosmic, ancestral, clinvar, qsignature, ACMG56_genes, transcripts]
     # RADAR -- currently having download problems, needs an update
     annotations_available: [battenberg, dbnsfp]
     validation: [giab-NA12878, platinum-genome-NA12878, giab-NA24385]
   - dbkey: GRCh37
     name: Human (GRCh37)
     annotations: [mirbase, GA4GH_problem_regions, MIG, prioritize, dbsnp, hapmap, 1000g_omni_snps, 1000g_snps,
-                  mills_indels, cosmic, ancestral, qsignature, ACMG56_genes, transcripts]
+                  mills_indels, cosmic, ancestral, clinvar, qsignature, ACMG56_genes, transcripts]
     # RADAR -- currently having download problems, needs an update
     annotations_available: [battenberg, dbnsfp]
     validation: [giab-NA12878, giab-NA24385, dream-syn3, dream-syn4]

--- a/ggd-recipes/GRCh37/clinvar.yaml
+++ b/ggd-recipes/GRCh37/clinvar.yaml
@@ -11,10 +11,10 @@ recipe:
     recipe_cmds:
       - |
         release=20160502
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive/2016/clinvar_${release}.vcf.gz
+        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive/2016/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
-        [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/clinvar.vcf.gz
+        [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | bgzip -c > variation/clinvar.vcf.gz
         tabix -f -p vcf variation/clinvar.vcf.gz
     recipe_outfiles:
       - variation/clinvar.vcf.gz

--- a/ggd-recipes/GRCh37/dbsnp.yaml
+++ b/ggd-recipes/GRCh37/dbsnp.yaml
@@ -1,18 +1,21 @@
+# UCSFify name sed magic from: https://github.com/mmarchin/utilities/blob/master/ucscify.sh
 ---
 attributes:
   name: dbsnp
-  version: 138
+  version: 147-20160408
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/2.8/b37/dbsnp_138.b37.vcf.gz
+        version=147
+        org=human_9606_b${version}_GRCh37p13
+        release=20160408
+        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
         mkdir -p variation
-        cd variation
-        wget -O - $baseurl | gunzip -c | bgzip -c > dbsnp_138.vcf.gz
-        tabix -f -p vcf dbsnp_138.vcf.gz
+        wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
+        [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | bgzip -c > variation/dbsnp-$version.vcf.gz
+        tabix -f -p vcf variation/dbsnp-$version.vcf.gz
     recipe_outfiles:
-      - variation/dbsnp_138.vcf.gz
-      - variation/dbsnp_138.vcf.gz.tbi
- 
+      - variation/dbsnp-147.vcf.gz
+      - variation/dbsnp-147.vcf.gz.tbi

--- a/ggd-recipes/hg19/clinvar.yaml
+++ b/ggd-recipes/hg19/clinvar.yaml
@@ -11,7 +11,7 @@ recipe:
     recipe_cmds:
       - |
         release=20160502
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive/2016/clinvar_${release}.vcf.gz
+        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive/2016/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
         [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/clinvar.vcf.gz

--- a/ggd-recipes/hg19/dbsnp.yaml
+++ b/ggd-recipes/hg19/dbsnp.yaml
@@ -1,18 +1,21 @@
+# UCSFify name sed magic from: https://github.com/mmarchin/utilities/blob/master/ucscify.sh
 ---
 attributes:
   name: dbsnp
-  version: 138
+  version: 147-20160408
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/2.8/hg19/dbsnp_138.hg19.vcf.gz
+        version=147
+        org=human_9606_b${version}_GRCh37p13
+        release=20160408
+        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
         mkdir -p variation
-        cd variation
-        wget -O - $baseurl | gunzip -c | bgzip -c > dbsnp_138.vcf.gz
-        tabix -f -p vcf dbsnp_138.vcf.gz
+        wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
+        [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/dbsnp-$version.vcf.gz
+        tabix -f -p vcf variation/dbsnp-$version.vcf.gz
     recipe_outfiles:
-      - variation/dbsnp_138.vcf.gz
-      - variation/dbsnp_138.vcf.gz.tbi
- 
+      - variation/dbsnp-147.vcf.gz
+      - variation/dbsnp-147.vcf.gz.tbi

--- a/ggd-recipes/hg38/dbsnp.yaml
+++ b/ggd-recipes/hg38/dbsnp.yaml
@@ -13,7 +13,7 @@ recipe:
         version=147
         org=human_9606_b${version}_GRCh38p2
         release=20160407
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_$release.vcf.gz
+        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/dbsnp-$version.vcf.gz


### PR DESCRIPTION
File refGene.txt.gz is downloaded from UCSC: http://hgdownload.cse.ucsc.edu/goldenPath/hg38/database/refGene.txt.gz
It's supposed to be used for annotation of BED files based on RefSeq genomic features, for Seq2C and possibly for other purposes, in replacement for add_genes() function that does not handle overlapping genes properly.

For dbSNP and ClinVar updates, see #223 discussion.