### PR TITLE
Fix building hisat2 indexes and correct an error in the hisat2 ggd recipe

### DIFF
--- a/ggd-recipes/hg38/hisat2.yaml
+++ b/ggd-recipes/hg38/hisat2.yaml
@@ -13,7 +13,7 @@ recipe:
       - |
         url=https://s3.amazonaws.com/biodata/genomes/hg38-hisat2-12-07-2015.tar.xz
         wget -qO- $url > hg38-hisat2-tar.xz
-        tar zxvf hg38-hisat2-tar.xz
+        tar Jxvf hg38-hisat2-tar.xz
         rm hg38-hisat2-tar.xz
     recipe_outfiles:
       -hisat2/hg38.1.ht2


### PR DESCRIPTION
_index_hisat2() creates the index dir to store exon and splicesite files in case a GTF file is available.  _index_w_command() only actually executes the index command if the index dir does not yet exist.  Fix
this by building the exon and splicesite files in a function passed down to _index_w_command().

With this fix "bcbio_nextgen.py upgrade --aligner hisat2" works again; both with the GGD recipe and by building the indexes locally.