### PR TITLE
Add tophat-recondition -- the bcbio-nextgen TopHat wrapper uses it now.

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -102,6 +102,7 @@ bio_nextgen:
   - svtyper
   - theta2
   - tophat
+  - tophat-recondition
   - tdrmapper
   - ucsc-bedtobigbed
   - ucsc-bigbedinfo

--- a/utils/prepare_tx_gff.py
+++ b/utils/prepare_tx_gff.py
@@ -756,7 +756,7 @@ def _get_gtf_db(gtf):
         print "Creating gffutils database for %s." % (gtf)
         disable_infer_transcripts, disable_infer_genes = guess_disable_infer_extent(gtf)
         if not disable_infer_transcripts or not disable_infer_genes:
-            print ("'transcript' or 'gene' entries not found, so inferring"
+            print ("'transcript' or 'gene' entries not found, so inferring "
                    "their extent. This can be very slow.")
         id_spec = guess_id_spec(gtf)
         gffutils.create_db(gtf, dbfn=db_file,


### PR DESCRIPTION
This adds tophat-recondition to the list of software to install, in support for chapmanb/bcbio-nextgen#1516.

Also fixes a missing whitespace in a message.