### PR TITLE
Fix version typo, "20l7" -> "2017".

### DIFF
--- a/ggd-recipes/GRCh37/vcfanno.yaml
+++ b/ggd-recipes/GRCh37/vcfanno.yaml
@@ -3,7 +3,7 @@
 ---
 attributes:
   name: vcfanno
-  version: 20l70105
+  version: 20170105
 recipe:
   full:
     recipe_type: bash

--- a/ggd-recipes/hg38/vcfanno.yaml
+++ b/ggd-recipes/hg38/vcfanno.yaml
@@ -3,7 +3,7 @@
 ---
 attributes:
   name: vcfanno
-  version: 20l70110
+  version: 20170110
 recipe:
   full:
     recipe_type: bash


### PR DESCRIPTION
Fixes an evil typo in the version field of vcfanno recipes.