### PR TITLE
updated dbNSFP to v3.4,updated dbSNP to v149, updated clinvar

### DIFF
--- a/ggd-recipes/GRCh37/dbnsfp.yaml
+++ b/ggd-recipes/GRCh37/dbnsfp.yaml
@@ -1,7 +1,7 @@
 ---
 attributes:
   name: dbnsfp
-  version: 3.3a
+  version: 3.4a
 recipe:
   full:
     recipe_type: bash
@@ -9,7 +9,7 @@ recipe:
       - |
         # Uses Google Drive for faster download with tricks from
         # http://stackoverflow.com/a/38937732/252589
-        ggID='0B60wROKy6OqceFMwVFBBbHAtR3M'
+        ggID='0B60wROKy6OqcS1dSc1d6aGxwd1k'
         ggURL='https://drive.google.com/uc?export=download'
         mkdir -p variation
         cd variation

--- a/ggd-recipes/GRCh37/dbsnp.yaml
+++ b/ggd-recipes/GRCh37/dbsnp.yaml
@@ -2,20 +2,20 @@
 ---
 attributes:
   name: dbsnp
-  version: 147-20160408
+  version: 149-20161121
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        version=147
+        version=149
         org=human_9606_b${version}_GRCh37p13
-        release=20160408
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
+        release=20161121
+        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | bgzip -c > variation/dbsnp-$version.vcf.gz
         tabix -f -p vcf variation/dbsnp-$version.vcf.gz
     recipe_outfiles:
-      - variation/dbsnp-147.vcf.gz
-      - variation/dbsnp-147.vcf.gz.tbi
+      - variation/dbsnp-149.vcf.gz
+      - variation/dbsnp-149.vcf.gz.tbi

--- a/ggd-recipes/hg19/dbsnp.yaml
+++ b/ggd-recipes/hg19/dbsnp.yaml
@@ -2,20 +2,20 @@
 ---
 attributes:
   name: dbsnp
-  version: 147-20160408
+  version: 149-20161121
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        version=147
+        version=149
         org=human_9606_b${version}_GRCh37p13
-        release=20160408
+        release=20161121
         url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/dbsnp-$version.vcf.gz
         tabix -f -p vcf variation/dbsnp-$version.vcf.gz
     recipe_outfiles:
-      - variation/dbsnp-147.vcf.gz
-      - variation/dbsnp-147.vcf.gz.tbi
+      - variation/dbsnp-149.vcf.gz
+      - variation/dbsnp-149.vcf.gz.tbi

--- a/ggd-recipes/hg38/clinvar.yaml
+++ b/ggd-recipes/hg38/clinvar.yaml
@@ -1,17 +1,17 @@
 # ClinVar: http://www.clinvar.com/
-# 
+#
 # UCSFify name sed magic from: https://github.com/mmarchin/utilities/blob/master/ucscify.sh
 ---
 attributes:
   name: clinvar
-  version: 20160502
+  version: 20170130
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        release=20160502
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive/2016/clinvar_${release}.vcf.gz
+        release=20170130
+        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive/2017/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
         [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/clinvar.vcf.gz

--- a/ggd-recipes/hg38/dbnsfp.yaml
+++ b/ggd-recipes/hg38/dbnsfp.yaml
@@ -1,7 +1,7 @@
 ---
 attributes:
   name: dbnsfp
-  version: 3.3a
+  version: 3.4a
 recipe:
   full:
     recipe_type: bash
@@ -9,7 +9,7 @@ recipe:
       - |
         # Uses Google Drive for faster download with tricks from
         # http://stackoverflow.com/a/38937732/252589
-        ggID='0B60wROKy6OqceFMwVFBBbHAtR3M'
+        ggID='0B60wROKy6OqcS1dSc1d6aGxwd1k'
         ggURL='https://drive.google.com/uc?export=download'
         mkdir -p variation
         cd variation

--- a/ggd-recipes/hg38/dbsnp.yaml
+++ b/ggd-recipes/hg38/dbsnp.yaml
@@ -1,5 +1,5 @@
 # dbSNP 144: http://www.ncbi.nlm.nih.gov/variation/docs/human_variation_vcf/
-# 
+#
 # UCSFify name sed magic from: https://github.com/mmarchin/utilities/blob/master/ucscify.sh
 ---
 attributes:

--- a/ggd-recipes/hg38/dbsnp.yaml
+++ b/ggd-recipes/hg38/dbsnp.yaml
@@ -1,23 +1,23 @@
-# dbSNP 144: http://www.ncbi.nlm.nih.gov/variation/docs/human_variation_vcf/
+# dbSNP 149: http://www.ncbi.nlm.nih.gov/variation/docs/human_variation_vcf/
 #
 # UCSFify name sed magic from: https://github.com/mmarchin/utilities/blob/master/ucscify.sh
 ---
 attributes:
   name: dbsnp
-  version: 147-20160407
+  version: 149-20161122
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        version=147
+        version=149
         org=human_9606_b${version}_GRCh38p2
-        release=20160407
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/archive/All_${release}.vcf.gz
+        release=20161122
+        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/dbsnp-$version.vcf.gz
         tabix -f -p vcf variation/dbsnp-$version.vcf.gz
     recipe_outfiles:
-      - variation/dbsnp-147.vcf.gz
-      - variation/dbsnp-147.vcf.gz.tbi
+      - variation/dbsnp-149.vcf.gz
+      - variation/dbsnp-149.vcf.gz.tbi


### PR DESCRIPTION
dbNSFP:
```
UPDATE (March 12, 2017): dbNSFP v3.4 and v2.9.3 are released. REVEL score (doi: 10.1016/j.ajhg.2016.08.016) and MutPred score (doi: 10.1093/bioinformatics/btp528) have been added. Please note REVEL is free for non-commercial usage only. SORVA gene ranking scores (doi: 10.1101/103218) have been added to gene annotation.
```