### PR TITLE
ensembl 91: updated conda requirement

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -47,7 +47,7 @@ bio_nextgen:
   - cyvcf2
   - delly
   - dkfz-bias-filter
-  - ensembl-vep=90.*
+  - ensembl-vep=91.*
   - ericscript;env=samtools0
   - express
   - extract-sv-reads


### PR DESCRIPTION
Small update for the new ensembl release
Merge pending conda recipe update, there's no github release of VEP yet.

I'll update when the conda recipe is available

Cheers
M