### PR TITLE
Fix checking environments for conda 4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ deploy/settings.yaml
 deploy/.venv-deploy
 deploy/.vagrant
 .ropeproject
+.idea


### PR DESCRIPTION
Starting version 4.4, `conda info --envs` returns environments from _all_ conda installations found in the system, identical to the `conda env list` command. Because of that, older bcbio installations and other user's conda envs might clash with the newly installed one. Fixing this issue by adding filtering the environments by `conda_prefix` (hoping that it reported consistently!).