### PR TITLE
GGD dbsnp: change FTP to HTTP

### DIFF
--- a/ggd-recipes/GRCh37/1000g_omni_snps.yaml
+++ b/ggd-recipes/GRCh37/1000g_omni_snps.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/1000G_omni2.5.b37.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/1000G_omni2.5.b37.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > 1000G_omni2.5.vcf.gz

--- a/ggd-recipes/GRCh37/1000g_snps.yaml
+++ b/ggd-recipes/GRCh37/1000g_snps.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/1000G_phase1.snps.high_confidence.b37.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/1000G_phase1.snps.high_confidence.b37.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > 1000G_phase1.snps.high_confidence.vcf.gz

--- a/ggd-recipes/GRCh37/clinvar.yaml
+++ b/ggd-recipes/GRCh37/clinvar.yaml
@@ -11,7 +11,7 @@ recipe:
     recipe_cmds:
       - |
         release=20170905
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive_2.0/2017/clinvar_${release}.vcf.gz
+        baseurl=http://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive_2.0/2017/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
         [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | bgzip -c > variation/clinvar.vcf.gz

--- a/ggd-recipes/GRCh37/dbscsnv.yaml
+++ b/ggd-recipes/GRCh37/dbscsnv.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbscSNV1.1.zip
+        baseurl=http://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbscSNV1.1.zip
         mkdir -p variation
         cd variation
         wget -c -N $baseurl

--- a/ggd-recipes/GRCh37/dbsnp.yaml
+++ b/ggd-recipes/GRCh37/dbsnp.yaml
@@ -11,7 +11,7 @@ recipe:
         version=150
         org=human_9606_b${version}_GRCh37p13
         release=20170710
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
+        url=http://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^chrM/MT/g" | sed "s/^chr//g" | bgzip -c > variation/dbsnp-$version.vcf.gz

--- a/ggd-recipes/GRCh37/giab-NA12878-NA24385-somatic.yaml
+++ b/ggd-recipes/GRCh37/giab-NA12878-NA24385-somatic.yaml
@@ -1,5 +1,5 @@
 # Truth set for NA12878/NA24385 somatic mixture
-# ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
+# http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
 ---
 attributes:
   name: giab-NA12878-NA24385-somatic
@@ -10,7 +10,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA12878-NA24385-somatic
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
         calls=na12878-na24385-somatic-truth.vcf.gz
         regions=na12878-na24385-somatic-truth-regions.bed
         mkdir -p $dir

--- a/ggd-recipes/GRCh37/giab-NA12878.yaml
+++ b/ggd-recipes/GRCh37/giab-NA12878.yaml
@@ -9,15 +9,15 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA12878
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh37/
         calls=HG001_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz
         regions=HG001_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel.bed
         mkdir -p $dir
         wget -c -O $dir/truth_small_variants.vcf.gz $url/$calls
         tabix -f -p vcf $dir/truth_small_variants.vcf.gz
         wget -c -O $dir/truth_regions.bed $url/$regions 
-        wget -O - ftp://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Personalis_1000_Genomes_deduplicated_deletions.bed | grep -v ^Chr > $dir/truth_DEL.bed
-        wget -O - ftp://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Spiral_Genetics_insertions.bed | grep -v ^Chr > $dir/truth_INS.bed
+        wget -O - http://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Personalis_1000_Genomes_deduplicated_deletions.bed | grep -v ^Chr > $dir/truth_DEL.bed
+        wget -O - http://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Spiral_Genetics_insertions.bed | grep -v ^Chr > $dir/truth_INS.bed
     recipe_outfiles:
       - validation/giab-NA12878/truth_small_variants.vcf.gz
       - validation/giab-NA12878/truth_small_variants.vcf.gz.tbi

--- a/ggd-recipes/GRCh37/giab-NA24385.yaml
+++ b/ggd-recipes/GRCh37/giab-NA24385.yaml
@@ -1,6 +1,6 @@
 # Truth sets from Genome in a Bottle for NA24385 -- http://genomeinabottle.org/
 # Structural variants from
-# ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_05092017/Preliminary_Integrations_v0.4.0/
+# http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_05092017/Preliminary_Integrations_v0.4.0/
 ---
 attributes:
   name: giab-NA24385
@@ -11,7 +11,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24385
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh37/
         calls=HG002_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-22_v.3.3.2_highconf_triophased.vcf.gz
         regions=HG002_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-22_v.3.3.2_highconf_noinconsistent.bed
         mkdir -p $dir
@@ -24,7 +24,7 @@ recipe:
         cnvurl=https://s3.amazonaws.com/bcbio/giab/NA24385/NA24385-crowd-dels-GRCh37.bed.gz
         wget -c -O $dir/truth_DEL_crowd.bed.gz $cnvurl
         wget -c -O $dir/truth_DEL_crowd.bed.gz.tbi $cnvurl.tbi
-        svurl=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_12122017/svanalyzer_union_171212_v0.5.0_annotated.vcf.gz
+        svurl=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_12122017/svanalyzer_union_171212_v0.5.0_annotated.vcf.gz
         wget -c -O $dir/truth_sv.vcf.gz $svurl
         wget -c -O $dir/truth_sv.vcf.gz.tbi $svurl.tbi
     recipe_outfiles:

--- a/ggd-recipes/GRCh37/giab-NA24631.yaml
+++ b/ggd-recipes/GRCh37/giab-NA24631.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24631
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh37/
         calls=HG005_GRCh37_highconf_CG-IllFB-IllGATKHC-Ion-SOLID_CHROM1-22_v.3.3.2_highconf.vcf.gz
         regions=HG005_GRCh37_highconf_CG-IllFB-IllGATKHC-Ion-SOLID_CHROM1-22_v.3.3.2_highconf_noMetaSV.bed
         mkdir -p $dir

--- a/ggd-recipes/GRCh37/gnomad.yaml
+++ b/ggd-recipes/GRCh37/gnomad.yaml
@@ -8,7 +8,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz
+        url=http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz
         ref=../seq/GRCh37.fa
         mkdir -p variation
         export TMPDIR=`pwd`

--- a/ggd-recipes/GRCh37/hapmap.yaml
+++ b/ggd-recipes/GRCh37/hapmap.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/hapmap_3.3.b37.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/hapmap_3.3.b37.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > hapmap_3.3.vcf.gz

--- a/ggd-recipes/GRCh37/mills_indels.yaml
+++ b/ggd-recipes/GRCh37/mills_indels.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > Mills_and_1000G_gold_standard.indels.vcf.gz

--- a/ggd-recipes/GRCh37/seq.yaml
+++ b/ggd-recipes/GRCh37/seq.yaml
@@ -1,5 +1,5 @@
 # GRCh37 reference genome from Broad bundle
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/b37
 # Include bgzipped fasta file for Ensembl and other tools that support it
 ---
 attributes:

--- a/ggd-recipes/GRCz11/seq.yaml
+++ b/ggd-recipes/GRCz11/seq.yaml
@@ -8,7 +8,7 @@ recipe:
     recipe_cmds:
       - |
         BUILD=GRCz11
-        url=ftp://ftp.ensembl.org/pub/release-92/fasta/danio_rerio/dna/Danio_rerio.GRCz11.dna.toplevel.fa.gz
+        url=http://ftp.ensembl.org/pub/release-92/fasta/danio_rerio/dna/Danio_rerio.GRCz11.dna.toplevel.fa.gz
         mkdir -p seq
         wget --no-check-certificate -O - $url | gunzip -c > seq/$BUILD.fa
         samtools faidx seq/$BUILD.fa

--- a/ggd-recipes/Sscrofa11.1/seq.yaml
+++ b/ggd-recipes/Sscrofa11.1/seq.yaml
@@ -8,7 +8,7 @@ recipe:
     recipe_cmds:
       - |
         BUILD=Sscrofa11.1
-        url=ftp://ftp.ensembl.org/pub/release-92/fasta/sus_scrofa/dna/Sus_scrofa.Sscrofa11.1.dna_rm.toplevel.fa.gz
+        url=http://ftp.ensembl.org/pub/release-92/fasta/sus_scrofa/dna/Sus_scrofa.Sscrofa11.1.dna_rm.toplevel.fa.gz
         mkdir -p seq
         wget --no-check-certificate -O - $url | gunzip -c > seq/$BUILD.fa
         samtools faidx seq/$BUILD.fa

--- a/ggd-recipes/TAIR10/mirbase.yaml
+++ b/ggd-recipes/TAIR10/mirbase.yaml
@@ -11,13 +11,13 @@ recipe:
         mkdir -p srnaseq
         cd srnaseq
 
-        wget -N -c -O tmp.gtf.gz ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/735/GCF_000001735.3_TAIR10/GCF_000001735.3_TAIR10_genomic.gff.gz
+        wget -N -c -O tmp.gtf.gz http://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/735/GCF_000001735.3_TAIR10/GCF_000001735.3_TAIR10_genomic.gff.gz
         zgrep -v exon tmp.gtf.gz | grep -v region | sed 's/Name/name/g' | sed 's/=/ /g' > srna-transcripts.gtf
-        wget -N -c -O hairpin.t.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz && gunzip -f hairpin.t.fa.gz
+        wget -N -c -O hairpin.t.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz && gunzip -f hairpin.t.fa.gz
         cat hairpin.t.fa | awk '{if ($0~/>ath/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget -N -c -O mature.t.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz && gunzip -f mature.t.fa.gz
+        wget -N -c -O mature.t.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz && gunzip -f mature.t.fa.gz
         cat mature.t.fa | awk '{if ($0~/>ath/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget -N -c -O miRNA.t.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz && gunzip -f miRNA.t.str.gz
+        wget -N -c -O miRNA.t.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz && gunzip -f miRNA.t.str.gz
         cat miRNA.t.str | awk '{if ($0~/ath/)print $0}' > miRNA.str
         wget --no-check-certificate -N -c -O Rfam_for_miRDeep.fa.gz https://github.com/lpantano/mirdeep2_core/raw/data/Rfam_for_miRDeep.fa.gz && gunzip -f Rfam_for_miRDeep.fa.gz
     recipe_outfiles:

--- a/ggd-recipes/hg19/1000g_omni_snps.yaml
+++ b/ggd-recipes/hg19/1000g_omni_snps.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/1000G_omni2.5.hg19.sites.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/1000G_omni2.5.hg19.sites.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > 1000G_omni2.5.vcf.gz

--- a/ggd-recipes/hg19/1000g_snps.yaml
+++ b/ggd-recipes/hg19/1000g_snps.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/1000G_phase1.snps.high_confidence.hg19.sites.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > 1000G_phase1.snps.high_confidence.vcf.gz

--- a/ggd-recipes/hg19/clinvar.yaml
+++ b/ggd-recipes/hg19/clinvar.yaml
@@ -11,7 +11,7 @@ recipe:
     recipe_cmds:
       - |
         release=20170905
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive_2.0/2017/clinvar_${release}.vcf.gz
+        baseurl=http://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh37/archive_2.0/2017/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
         [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/clinvar.vcf.gz

--- a/ggd-recipes/hg19/dbsnp.yaml
+++ b/ggd-recipes/hg19/dbsnp.yaml
@@ -11,7 +11,7 @@ recipe:
         version=150
         org=human_9606_b${version}_GRCh37p13
         release=20170710
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
+        url=http://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | bgzip -c > variation/dbsnp-$version.vcf.gz

--- a/ggd-recipes/hg19/giab-NA12878.yaml
+++ b/ggd-recipes/hg19/giab-NA12878.yaml
@@ -12,7 +12,7 @@ recipe:
       - |
         dir=validation/giab-NA12878
         remapurl=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh37/
         calls=HG001_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz
         regions=HG001_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel.bed
         mkdir -p $dir
@@ -20,8 +20,8 @@ recipe:
         wget -c -O - $url/$calls | gunzip -c | sed -f remap.sed | grep -v "##contig=" | bgzip -c > $dir/truth_small_variants.vcf.gz
         tabix -f -p vcf $dir/truth_small_variants.vcf.gz
         wget -c -O - $url/$regions | sed -f remap.sed > $dir/truth_regions.bed
-        wget -O - ftp://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Personalis_1000_Genomes_deduplicated_deletions.bed | grep -v ^Chr | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" > $dir/truth_DEL.bed
-        wget -O -  ftp://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Spiral_Genetics_insertions.bed | grep -v ^Chr | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" > $dir/truth_INS.bed
+        wget -O - http://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Personalis_1000_Genomes_deduplicated_deletions.bed | grep -v ^Chr | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" > $dir/truth_DEL.bed
+        wget -O -  http://ftp.ncbi.nih.gov/giab/ftp/technical/svclassify_Manuscript/Supplementary_Information/Spiral_Genetics_insertions.bed | grep -v ^Chr | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" > $dir/truth_INS.bed
     recipe_outfiles:
       - validation/giab-NA12878/truth_small_variants.vcf.gz
       - validation/giab-NA12878/truth_small_variants.vcf.gz.tbi

--- a/ggd-recipes/hg19/giab-NA24385.yaml
+++ b/ggd-recipes/hg19/giab-NA24385.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24385
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh37/
         calls=HG002_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-22_v.3.3.2_highconf_triophased.vcf.gz
         regions=HG002_GRCh37_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-22_v.3.3.2_highconf_noinconsistent.bed
         remapurl=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
@@ -24,7 +24,7 @@ recipe:
         cnvurl=https://s3.amazonaws.com/bcbio/giab/NA24385/NA24385-crowd-dels-hg19.bed.gz
         wget -c -O $dir/truth_DEL_crowd.bed.gz $cnvurl
         wget -c -O $dir/truth_DEL_crowd.bed.gz.tbi $cnvurl.tbi
-        svurl=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_12122017/svanalyzer_union_171212_v0.5.0_annotated.vcf.gz
+        svurl=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/analysis/NIST_UnionSVs_12122017/svanalyzer_union_171212_v0.5.0_annotated.vcf.gz
         wget -c -O - $svurl | gunzip -c | sed -f remap.sed | grep -v "##contig=" | bgzip -c > $dir/truth_sv.vcf.gz
         tabix -f -p vcf $dir/truth_sv.vcf.gz
     recipe_outfiles:

--- a/ggd-recipes/hg19/giab-NA24631.yaml
+++ b/ggd-recipes/hg19/giab-NA24631.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24631
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh37/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh37/
         calls=HG005_GRCh37_highconf_CG-IllFB-IllGATKHC-Ion-SOLID_CHROM1-22_v.3.3.2_highconf.vcf.gz
         regions=HG005_GRCh37_highconf_CG-IllFB-IllGATKHC-Ion-SOLID_CHROM1-22_v.3.3.2_highconf_noMetaSV.bed
         remapurl=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt

--- a/ggd-recipes/hg19/gnomad.yaml
+++ b/ggd-recipes/hg19/gnomad.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz
+        url=http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad.genomes.r2.0.1.sites.noVEP.vcf.gz
         remap_url=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
         ref=../seq/hg19.fa
         mkdir -p variation

--- a/ggd-recipes/hg19/hapmap.yaml
+++ b/ggd-recipes/hg19/hapmap.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/hapmap_3.3.hg19.sites.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/hapmap_3.3.hg19.sites.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > hapmap_3.3.vcf.gz

--- a/ggd-recipes/hg19/mills_indels.yaml
+++ b/ggd-recipes/hg19/mills_indels.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz
+        baseurl=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19/Mills_and_1000G_gold_standard.indels.hg19.sites.vcf.gz
         mkdir -p variation
         cd variation
         wget -O - $baseurl | gunzip -c | bgzip -c > Mills_and_1000G_gold_standard.indels.vcf.gz

--- a/ggd-recipes/hg19/mirbase.yaml
+++ b/ggd-recipes/hg19/mirbase.yaml
@@ -10,7 +10,7 @@ recipe:
       - |
         mkdir -p srnaseq
         cd srnaseq
-        wget --random-wait --retry-connrefused -q -N -c -O hsahg19.gff3 ftp://mirbase.org/pub/mirbase/20/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O hsahg19.gff3 http://mirbase.org/pub/mirbase/20/genomes/hsa.gff3
         awk '$3=="miRNA"' hsahg19.gff3 | sed 's/=/ /g' > srna-transcripts.gtf
         wget  --random-wait --retry-connrefused -q -N -c -O wgRna.txt.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg19/database/wgRna.txt.gz
         zgrep -v 'hsa-' wgRna.txt.gz | awk '{print $2"\t.\tncrna\t"$3"\t"$4"\t.\t"$7"\t.\tname "$5";"}' >> srna-transcripts.gtf
@@ -23,13 +23,13 @@ recipe:
         # wget http://www.regulatoryrna.org/database/piRNA/download/archive/v1.0/bed/piR_hg19_v1.0.bed.gz
         # zcat piR_hg19_v1.0.bed.gz | awk '{print $1"\t.\tpiRNA\t"$2"\t"$3"\t.\t"$6"\t.\tname "$4";"}' >> srna-transcripts.gtf
         # mirbase
-        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz
         zcat hairpin.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz
         zcat mature.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz
         zcat miRNA.str.gz | awk '{if ($0~/hsa/)print $0}' > miRNA.str
-        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 ftp://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 http://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
         #tdrmapper
         wget   --random-wait --retry-connrefused  --no-check-certificate -q -N -c -O trna_mature_pre.fa https://github.com/sararselitsky/tDRmapper/raw/master/hg19_mature_and_pre.fa
         # mintmap
@@ -41,7 +41,7 @@ recipe:
         # targetscan analysis
         wget  --random-wait --retry-connrefused --no-check-certificate -q -N -c -O Summary_Counts.txt.zip http://www.targetscan.org/vert_71/vert_71_data_download/Summary_Counts.all_predictions.txt.zip && unzip Summary_Counts.txt.zip
         wget  --random-wait --retry-connrefused --no-check-certificate -q -N -c -O miR_Family_Info.txt.zip http://www.targetscan.org/vert_71/vert_71_data_download/miR_Family_Info.txt.zip && unzip miR_Family_Info.txt.zip
-        wget  --random-wait --retry-connrefused --no-check-certificate -q -N -c ftp://mirbase.org/pub/mirbase/21/database_files/mirna_mature.txt.gz
+        wget  --random-wait --retry-connrefused --no-check-certificate -q -N -c http://mirbase.org/pub/mirbase/21/database_files/mirna_mature.txt.gz
     recipe_outfiles:
         - srnaseq/srna-transcripts.gtf
         - srnaseq/hairpin.fa

--- a/ggd-recipes/hg19/seq.yaml
+++ b/ggd-recipes/hg19/seq.yaml
@@ -1,5 +1,5 @@
 # hg19 reference genome from Broad bundle
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg19
 # Include bgzipped fasta file for Ensembl and other tools that support it
 ---
 attributes:

--- a/ggd-recipes/hg38-noalt/README.md
+++ b/ggd-recipes/hg38-noalt/README.md
@@ -1,3 +1,3 @@
 Human reference genome: GRCh38/hg38 without any alternative reference contigs
 
-ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/
+http://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids/

--- a/ggd-recipes/hg38-noalt/bowtie2.yaml
+++ b/ggd-recipes/hg38-noalt/bowtie2.yaml
@@ -10,7 +10,7 @@ recipe:
       - |
         base=GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.bowtie_index
         new=hg38-noalt.fa
-        ncbiurl=ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
+        ncbiurl=http://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
         wget -c $ncbiurl/$base.tar.gz
         [[ -f $base.1.bt2 ]] || tar -xzvpf $base.tar.gz
         mkdir -p bowtie2

--- a/ggd-recipes/hg38-noalt/bwa.yaml
+++ b/ggd-recipes/hg38-noalt/bwa.yaml
@@ -10,7 +10,7 @@ recipe:
       - |
         base=GCA_000001405.15_GRCh38_no_alt_analysis_set.fna
         new=hg38-noalt.fa
-        ncbiurl=ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
+        ncbiurl=http://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
         wget -c $ncbiurl/$base.bwa_index.tar.gz
         [[ -f $base.fna.bwt ]] || tar -xzvpf $base.bwa_index.tar.gz
         mkdir -p bwa

--- a/ggd-recipes/hg38-noalt/gtf.yaml
+++ b/ggd-recipes/hg38-noalt/gtf.yaml
@@ -10,7 +10,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-	url=ftp://ftp.ensembl.org/pub/release-78/gtf/homo_sapiens/Homo_sapiens.GRCh38.78.gtf.gz
+	url=http://ftp.ensembl.org/pub/release-78/gtf/homo_sapiens/Homo_sapiens.GRCh38.78.gtf.gz
         mkdir -p rnaseq
         remap_url=http://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh38_ensembl2UCSC.txt
         wget -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed

--- a/ggd-recipes/hg38-noalt/mirbase.yaml
+++ b/ggd-recipes/hg38-noalt/mirbase.yaml
@@ -10,7 +10,7 @@ recipe:
       - |
         mkdir -p srnaseq
         cd srnaseq
-        wget --random-wait --retry-connrefused -q -N -c -O hsa.gff3 ftp://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O hsa.gff3 http://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
         awk '$3=="miRNA"' hsa.gff3 | sed 's/=/ /g' > srna-transcripts.gtf
         wget  --random-wait --retry-connrefused -q -N -c -O wgRna.txt.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/wgRna.txt.gz
         zgrep -v 'hsa-' wgRna.txt.gz | awk '{print $2"\t.\tncrna\t"$3"\t"$4"\t.\t"$7"\t.\tname "$5";"}' >> srna-transcripts.gtf
@@ -24,13 +24,13 @@ recipe:
         # wget http://www.regulatoryrna.org/database/piRNA/download/archive/v1.0/bed/piR_hg19_v1.0.bed.gz
         # zcat piR_hg19_v1.0.bed.gz | awk '{print $1"\t.\tpiRNA\t"$2"\t"$3"\t.\t"$6"\t.\tname "$4";"}' >> srna-transcripts.gtf
         # mirbase
-        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz
         zcat hairpin.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz
         zcat mature.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz
         zcat miRNA.str.gz | awk '{if ($0~/hsa/)print $0}' > miRNA.str
-        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 ftp://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 http://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
         #tdrmapper
         wget   --random-wait --retry-connrefused  --no-check-certificate -q -N -c -O trna_mature_pre.fa https://github.com/sararselitsky/tDRmapper/raw/master/hg19_mature_and_pre.fa
         # mintmap

--- a/ggd-recipes/hg38-noalt/seq.yaml
+++ b/ggd-recipes/hg38-noalt/seq.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         mkdir -p seq
-        ncbidir=ftp://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
+        ncbidir=http://ftp.ncbi.nlm.nih.gov/genomes/genbank/vertebrate_mammalian/Homo_sapiens/all_assembly_versions/GCA_000001405.15_GRCh38/seqs_for_alignment_pipelines.ucsc_ids
         filebase=GCA_000001405.15_GRCh38_no_alt_analysis_set.fna
         wget -c -O - $ncbidir/${filebase}.gz | gunzip -c > seq/hg38-noalt.fa
       - wget -c -O seq/hg38-noalt.fa.fai $ncbidir/${filebase}.fai

--- a/ggd-recipes/hg38/1000g_omni_snps.yaml
+++ b/ggd-recipes/hg38/1000g_omni_snps.yaml
@@ -2,7 +2,7 @@
 # http://www.1000genomes.org/category/frequently-asked-questions/omni
 #
 # From the Broad hg38 bundle:
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
 # https://www.broadinstitute.org/gatk/guide/article.php?id=1213
 ---
 attributes:
@@ -13,7 +13,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
+        url=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
         new=1000G_omni2.5
         base=$new.hg38
         mkdir -p variation

--- a/ggd-recipes/hg38/1000g_snps.yaml
+++ b/ggd-recipes/hg38/1000g_snps.yaml
@@ -1,7 +1,7 @@
 # 1000 genomes phase 1 SNP calls
 #
 # From the Broad hg38 bundle:
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
 # https://www.broadinstitute.org/gatk/guide/article.php?id=1213
 ---
 attributes:
@@ -12,7 +12,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
+        url=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
         new=1000G_phase1.snps.high_confidence
         base=$new.hg38
         mkdir -p variation

--- a/ggd-recipes/hg38/README.md
+++ b/ggd-recipes/hg38/README.md
@@ -1,3 +1,3 @@
 Full hg38/GRCh38 reference genome distributed by 1000 genomes
 Derived from NCBI set with HLA and decoy alternative alleles
-ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
+http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/

--- a/ggd-recipes/hg38/bwa.yaml
+++ b/ggd-recipes/hg38/bwa.yaml
@@ -1,6 +1,6 @@
 # Full hg38/GRCh38 reference genome distributed by 1000 genomes
 # Derived from NCBI set with HLA and decoy alternative alleles
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
+# http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
 # Pre-build bwa indices
 ---
 attributes:
@@ -11,7 +11,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome
+        url=http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome
         base=GRCh38_full_analysis_set_plus_decoy_hla.fa
         new=hg38.fa
         mkdir -p bwa

--- a/ggd-recipes/hg38/clinvar.yaml
+++ b/ggd-recipes/hg38/clinvar.yaml
@@ -11,7 +11,7 @@ recipe:
     recipe_cmds:
       - |
         release=20170905
-        baseurl=ftp://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive_2.0/2017/clinvar_${release}.vcf.gz
+        baseurl=http://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/archive_2.0/2017/clinvar_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/clinvar-orig.vcf.gz $baseurl
         [[ -f variation/clinvar.vcf.gz ]] || zcat variation/clinvar-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/clinvar.vcf.gz

--- a/ggd-recipes/hg38/dbscsnv.yaml
+++ b/ggd-recipes/hg38/dbscsnv.yaml
@@ -7,7 +7,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        baseurl=ftp://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbscSNV1.1.zip
+        baseurl=http://dbnsfp:dbnsfp@dbnsfp.softgenetics.com/dbscSNV1.1.zip
         mkdir -p variation
         cd variation
         wget -c -N $baseurl

--- a/ggd-recipes/hg38/dbsnp.yaml
+++ b/ggd-recipes/hg38/dbsnp.yaml
@@ -13,7 +13,7 @@ recipe:
         version=150
         org=human_9606_b${version}_GRCh38p7
         release=20170710
-        url=ftp://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
+        url=http://ftp.ncbi.nih.gov/snp/organisms/$org/VCF/GATK/All_${release}.vcf.gz
         mkdir -p variation
         wget -c -O variation/dbsnp-$version-orig.vcf.gz $url
         [[ -f variation/dbsnp-$version.vcf.gz ]] || zcat variation/dbsnp-$version-orig.vcf.gz | sed "s/^\([0-9]\+\)\t/chr\1\t/g" | sed "s/^MT/chrM/g" | sed "s/^X/chrX/g" | sed "s/^Y/chrY/g" | bgzip -c > variation/dbsnp-$version.vcf.gz

--- a/ggd-recipes/hg38/giab-NA12878-NA24385-somatic.yaml
+++ b/ggd-recipes/hg38/giab-NA12878-NA24385-somatic.yaml
@@ -1,5 +1,5 @@
 # Truth set for NA12878/NA24385 somatic mixture
-# ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
+# http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/use_cases/mixtures/UMCUTRECHT_NA12878_NA24385_mixture_10052016/
 ---
 attributes:
   name: giab-NA12878-NA24385-somatic

--- a/ggd-recipes/hg38/giab-NA12878.yaml
+++ b/ggd-recipes/hg38/giab-NA12878.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA12878
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh38/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/NA12878_HG001/NISTv3.3.2/GRCh38/
         calls=HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_PGandRTGphasetransfer.vcf.gz
         regions=HG001_GRCh38_GIAB_highconf_CG-IllFB-IllGATKHC-Ion-10X-SOLID_CHROM1-X_v.3.3.2_highconf_nosomaticdel_noCENorHET7.bed
         mkdir -p $dir

--- a/ggd-recipes/hg38/giab-NA24385.yaml
+++ b/ggd-recipes/hg38/giab-NA24385.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24385
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh38/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/AshkenazimTrio/HG002_NA24385_son/NISTv3.3.2/GRCh38/
         calls=HG002_GRCh38_GIAB_highconf_CG-Illfb-IllsentieonHC-Ion-10XsentieonHC-SOLIDgatkHC_CHROM1-22_v.3.3.2_highconf_triophased.vcf.gz
         regions=HG002_GRCh38_GIAB_highconf_CG-Illfb-IllsentieonHC-Ion-10XsentieonHC-SOLIDgatkHC_CHROM1-22_v.3.3.2_highconf_noinconsistent.bed
         mkdir -p $dir

--- a/ggd-recipes/hg38/giab-NA24631.yaml
+++ b/ggd-recipes/hg38/giab-NA24631.yaml
@@ -9,7 +9,7 @@ recipe:
     recipe_cmds:
       - |
         dir=validation/giab-NA24631
-        url=ftp://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh38/
+        url=http://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/release/ChineseTrio/HG005_NA24631_son/NISTv3.3.2/GRCh38/
         calls=HG005_GRCh38_GIAB_highconf_CG-Illfb-IllsentieonHC-Ion-10XsentieonHC-SOLIDgatkHC_CHROM1-22_v.3.3.2_highconf.vcf.gz
         regions=HG005_GRCh38_GIAB_highconf_CG-Illfb-IllsentieonHC-Ion-10XsentieonHC-SOLIDgatkHC_CHROM1-22_v.3.3.2_highconf.bed
         mkdir -p $dir

--- a/ggd-recipes/hg38/gnomad.yaml
+++ b/ggd-recipes/hg38/gnomad.yaml
@@ -10,7 +10,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad.genomes.r2.0.1.sites.GRCh38.noVEP.vcf.gz
+        url=http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad.genomes.r2.0.1.sites.GRCh38.noVEP.vcf.gz
         remap_url=http://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh38_ensembl2UCSC.txt
         ref=../seq/hg38.fa
         mkdir -p variation

--- a/ggd-recipes/hg38/gtf.yaml
+++ b/ggd-recipes/hg38/gtf.yaml
@@ -10,7 +10,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-	url=ftp://ftp.ensembl.org/pub/release-78/gtf/homo_sapiens/Homo_sapiens.GRCh38.78.gtf.gz
+	url=http://ftp.ensembl.org/pub/release-78/gtf/homo_sapiens/Homo_sapiens.GRCh38.78.gtf.gz
         mkdir -p rnaseq
         remap_url=http://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh38_ensembl2UCSC.txt
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed

--- a/ggd-recipes/hg38/hapmap_snps.yaml
+++ b/ggd-recipes/hg38/hapmap_snps.yaml
@@ -1,7 +1,7 @@
 # HapMap v3.3 SNP calls
 #
 # From the Broad hg38 bundle:
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
 # https://www.broadinstitute.org/gatk/guide/article.php?id=1213
 ---
 attributes:
@@ -12,7 +12,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
+        url=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
         new=hapmap_3.3
         base=$new.hg38
         mkdir -p variation

--- a/ggd-recipes/hg38/hisat2.yaml
+++ b/ggd-recipes/hg38/hisat2.yaml
@@ -1,6 +1,6 @@
 # hisat2 (v2.0.1) reference with Ensembl release 78 exon and splicesite annotations
 # Derived from NCBI set with HLA and decoy alternative alleles
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
+# http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
 # README.md has an in depth description of how this was created
 ---
 attributes:

--- a/ggd-recipes/hg38/mills_indels.yaml
+++ b/ggd-recipes/hg38/mills_indels.yaml
@@ -3,7 +3,7 @@
 # http://genome.cshlp.org/content/21/6/830.full
 #
 # From the Broad hg38 bundle:
-# ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
+# http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/
 # https://www.broadinstitute.org/gatk/guide/article.php?id=1213
 ---
 attributes:
@@ -14,7 +14,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
+        url=http://gsapubftp-anonymous:none@ftp.broadinstitute.org/bundle/hg38/
         base=Mills_and_1000G_gold_standard.indels.hg38
         new=Mills_and_1000G_gold_standard.indels
         mkdir -p variation

--- a/ggd-recipes/hg38/mirbase.yaml
+++ b/ggd-recipes/hg38/mirbase.yaml
@@ -10,7 +10,7 @@ recipe:
       - |
         mkdir -p srnaseq
         cd srnaseq
-        wget --random-wait --retry-connrefused -q -N -c -O hsa.gff3 ftp://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O hsa.gff3 http://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
         awk '$3=="miRNA"' hsa.gff3 | sed 's/=/ /g' > srna-transcripts.gtf
         wget  --random-wait --retry-connrefused -q -N -c -O wgRna.txt.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/wgRna.txt.gz
         zgrep -v 'hsa-' wgRna.txt.gz | awk '{print $2"\t.\tncrna\t"$3"\t"$4"\t.\t"$7"\t.\tname "$5";"}' >> srna-transcripts.gtf
@@ -24,13 +24,13 @@ recipe:
         # wget http://www.regulatoryrna.org/database/piRNA/download/archive/v1.0/bed/piR_hg19_v1.0.bed.gz
         # zcat piR_hg19_v1.0.bed.gz | awk '{print $1"\t.\tpiRNA\t"$2"\t"$3"\t.\t"$6"\t.\tname "$4";"}' >> srna-transcripts.gtf
         # mirbase
-        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O hairpin.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz
         zcat hairpin.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O mature.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz
         zcat mature.fa.gz |  awk '{if ($0~/>hsa/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz
+        wget  --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz
         zcat miRNA.str.gz | awk '{if ($0~/hsa/)print $0}' > miRNA.str
-        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 ftp://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
+        wget --random-wait --retry-connrefused -q -N -c -O mirbase.gff3 http://mirbase.org/pub/mirbase/21/genomes/hsa.gff3
         #tdrmapper
         wget   --random-wait --retry-connrefused  --no-check-certificate -q -N -c -O trna_mature_pre.fa https://github.com/sararselitsky/tDRmapper/raw/master/hg19_mature_and_pre.fa
         # mintmap

--- a/ggd-recipes/hg38/seq.yaml
+++ b/ggd-recipes/hg38/seq.yaml
@@ -1,6 +1,6 @@
 # Full hg38/GRCh38 reference genome distributed by 1000 genomes
 # Derived from NCBI set with HLA and decoy alternative alleles
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
+# http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
 ---
 attributes:
   name: seq
@@ -10,7 +10,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome
+        url=http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome
         base=GRCh38_full_analysis_set_plus_decoy_hla
         new=hg38
         mkdir -p seq

--- a/ggd-recipes/mm10/mirbase.yaml
+++ b/ggd-recipes/mm10/mirbase.yaml
@@ -16,19 +16,19 @@ recipe:
         zcat tRNAs.txt.gz | awk '{print $2"\t.\ttRNA\t"$3+1"\t"$4"\t.\t"$7"\t.\tname "$5";"}' >> srna-transcripts.gtf
         wget  --random-wait --retry-connrefused -q -N -c http://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/rmsk.txt.gz
         zcat rmsk.txt.gz | awk '{print $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' >> srna-transcripts.gtf
-        wget  --random-wait --retry-connrefused -q -N -c ftp://mirbase.org/pub/mirbase/20/genomes/mmu.gff3
+        wget  --random-wait --retry-connrefused -q -N -c http://mirbase.org/pub/mirbase/20/genomes/mmu.gff3
         awk '$3=="miRNA"' mmu.gff3 | sed 's/=/ /g' >> srna-transcripts.gtf
-        wget  --random-wait --retry-connrefused -q -N -c -O hairpin.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz
+        wget  --random-wait --retry-connrefused -q -N -c -O hairpin.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz
         zcat hairpin.fa.gz |  awk '{if ($0~/>mmu/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget  --random-wait --retry-connrefused -q -N -c -O mature.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz
+        wget  --random-wait --retry-connrefused -q -N -c -O mature.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz
         zcat mature.fa.gz |  awk '{if ($0~/>mmu/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz
+        wget --random-wait --retry-connrefused  -q -N -c -O miRNA.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz
         zcat miRNA.str.gz | awk '{if ($0~/mmu/)print $0}' > miRNA.str
         wget --random-wait --retry-connrefused  --no-check-certificate -q -N -c -O Rfam_for_miRDeep.fa.gz https://github.com/lpantano/mirdeep2_core/raw/data/Rfam_for_miRDeep.fa.gz && gunzip Rfam_for_miRDeep.fa.gz
         # targetscan analysis
         # wget --no-check-certificate -q -N -c -O Summary_Counts.txt.zip http://www.targetscan.org/mmu_71/mmu_71_data_download/Summary_Counts.all_predictions.txt.zip && unzip Summary_Counts.txt.zip
         # wget --no-check-certificate -q -N -c -O miR_Family_Info.txt.zip http://www.targetscan.org/mmu_71/mmu_71_data_download/miR_Family_Info.txt.zip && unzip miR_Family_Info.txt.zip
-        # wget --no-check-certificate -q -N -c ftp://mirbase.org/pub/mirbase/21/database_files/mirna_mature.txt.gz
+        # wget --no-check-certificate -q -N -c http://mirbase.org/pub/mirbase/21/database_files/mirna_mature.txt.gz
         # tdrmapper
         wget  --random-wait --retry-connrefused --no-check-certificate -N -c -O trna_mature_pre.fa https://github.com/sararselitsky/tDRmapper/raw/master/mm10_mature_pre_for_tdrMapper.fa
     recipe_outfiles:

--- a/ggd-recipes/rn6/mirbase.yaml
+++ b/ggd-recipes/rn6/mirbase.yaml
@@ -10,17 +10,17 @@ recipe:
       - |
         mkdir -p srnaseq
         cd srnaseq
-        wget -q -N -c ftp://ftp.ensembl.org/pub/release-86/gtf/rattus_norvegicus/Rattus_norvegicus.Rnor_6.0.86.gtf.gz
+        wget -q -N -c http://ftp.ensembl.org/pub/release-86/gtf/rattus_norvegicus/Rattus_norvegicus.Rnor_6.0.86.gtf.gz
         zcat  Rattus_norvegicus.Rnor_6.0.86.gtf.gz | awk '$5-$4 < 500' | grep -v "^#"> srna-transcripts.gtf
         wget -q -N -c http://hgdownload.soe.ucsc.edu/goldenPath/rn6/database/rmsk.txt.gz
         zcat rmsk.txt.gz | awk '{print $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' | sed 's/^chr//' | sed 's/^M/MT/' >> srna-transcripts.gtf
-        # wget -q -N -c ftp://mirbase.org/pub/mirbase/20/genomes/rno.gff3
+        # wget -q -N -c http://mirbase.org/pub/mirbase/20/genomes/rno.gff3
         # awk '$3=="miRNA"' mmu.gff3 | sed 's/=/ /g' >> srna-transcripts.gtf
-        wget -q -N -c -O hairpin.fa.gz ftp://mirbase.org/pub/mirbase/21/hairpin.fa.gz
+        wget -q -N -c -O hairpin.fa.gz http://mirbase.org/pub/mirbase/21/hairpin.fa.gz
         zcat hairpin.fa.gz |  awk '{if ($0~/>rno/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > hairpin.fa
-        wget -q -N -c -O mature.fa.gz ftp://mirbase.org/pub/mirbase/21/mature.fa.gz
+        wget -q -N -c -O mature.fa.gz http://mirbase.org/pub/mirbase/21/mature.fa.gz
         zcat mature.fa.gz |  awk '{if ($0~/>rno/){name=$0; print name} else if ($0~/^>/){name=0};if (name!=0 && $0!~/^>/){print $0;}}' | sed 's/U/T/g'  > mature.fa
-        wget -q -N -c -O miRNA.str.gz ftp://mirbase.org/pub/mirbase/21/miRNA.str.gz
+        wget -q -N -c -O miRNA.str.gz http://mirbase.org/pub/mirbase/21/miRNA.str.gz
         zcat miRNA.str.gz | awk '{if ($0~/rno/)print $0}' > miRNA.str
         wget --no-check-certificate -q -N -c -O Rfam_for_miRDeep.fa.gz https://github.com/lpantano/mirdeep2_core/raw/data/Rfam_for_miRDeep.fa.gz && gunzip Rfam_for_miRDeep.fa.gz
         # targetscan analysis

--- a/ggd-recipes/rn6/seq.yaml
+++ b/ggd-recipes/rn6/seq.yaml
@@ -1,6 +1,6 @@
 # Full hg38/GRCh38 reference genome distributed by 1000 genomes
 # Derived from NCBI set with HLA and decoy alternative alleles
-# ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
+# http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/technical/reference/GRCh38_reference_genome/
 ---
 attributes:
   name: seq
@@ -10,7 +10,7 @@ recipe:
     recipe_type: bash
     recipe_cmds:
       - |
-        url=ftp://ftp.ensembl.org/pub/release-85/fasta/rattus_norvegicus/dna/Rattus_norvegicus.Rnor_6.0.dna.toplevel.fa.gz
+        url=http://ftp.ensembl.org/pub/release-85/fasta/rattus_norvegicus/dna/Rattus_norvegicus.Rnor_6.0.dna.toplevel.fa.gz
         mkdir -p seq
         wget --no-check-certificate -O - $url | gunzip -c > seq/rn6.fa
     recipe_outfiles:


### PR DESCRIPTION
Some clusters do not allow FTP downloads, causing errors during install.
Switching to http fixes that issue.

Cheers
M