### PR TITLE
normalize gnomad exome and genome vcf for hg19, hg38, grch37

### DIFF
--- a/ggd-recipes/GRCh37/gnomad.yaml
+++ b/ggd-recipes/GRCh37/gnomad.yaml
@@ -12,7 +12,7 @@ recipe:
         ref=../seq/GRCh37.fa
         mkdir -p variation
         export TMPDIR=`pwd`
-        vt decompose -s $url | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
+        vt decompose -s $url | vt normalize -r $ref -n | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
         tabix -f -p vcf variation/gnomad_genome.vcf.gz
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz

--- a/ggd-recipes/GRCh37/gnomad_exome.yaml
+++ b/ggd-recipes/GRCh37/gnomad_exome.yaml
@@ -12,7 +12,7 @@ recipe:
         ref=`ls ../seq/*.fa.fai`
         mkdir -p variation
         export TMPDIR=`pwd`
-        vt decompose -s $url | gsort -m 3000 /dev/stdin $ref | bgzip -c > variation/gnomad_exome.vcf.gz
+        vt decompose -s $url | vt normalize -r $ref -n | gsort -m 3000 /dev/stdin $ref | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:

--- a/ggd-recipes/hg19/gnomad.yaml
+++ b/ggd-recipes/hg19/gnomad.yaml
@@ -15,7 +15,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
         export TMPDIR=`pwd`
-        wget -c -O - $url | gunzip -c | vt decompose -s - | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
+        wget -c -O - $url | gunzip -c | vt decompose -s - | vt normalize -r $ref -n | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
         tabix -f -p vcf variation/gnomad_genome.vcf.gz
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz

--- a/ggd-recipes/hg19/gnomad_exome.yaml
+++ b/ggd-recipes/hg19/gnomad_exome.yaml
@@ -10,11 +10,11 @@ recipe:
       - |
         url=http://ftp.ensembl.org/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad.exomes.r2.0.1.sites.noVEP.vcf.gz
         remap_url=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
-        ref=`ls ../seq/*.fa.fai`
+        ref=../seq/hg19.fa
         mkdir -p variation
         export TMPDIR=`pwd`
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
-        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | gsort -m 3000 /dev/stdin $ref | bgzip -c > variation/gnomad_exome.vcf.gz
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | vt normalize -r $ref -n | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:

--- a/ggd-recipes/hg38/gnomad.yaml
+++ b/ggd-recipes/hg38/gnomad.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
         export TMPDIR=`pwd`
-        vt decompose -s $url | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
+        vt decompose -s $url | vt normalize -r $ref -n | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
         tabix -f -p vcf variation/gnomad_genome.vcf.gz
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz

--- a/ggd-recipes/hg38/gnomad_exome.yaml
+++ b/ggd-recipes/hg38/gnomad_exome.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
         export TMPDIR=`pwd`
-        vt decompose -s $url | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
+        vt decompose -s $url | vt normalize -r $ref -n | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:


### PR DESCRIPTION
When vcf's from gnomad exome/genome are installed, they need to be normalized, otherwise later vcfanno  is not able to match some indels and annotates high frequency indels with low frequency in general population. Solves https://github.com/bcbio/bcbio-nextgen/issues/2503