### PR TITLE
Fixes gnomad_exome.vcf.gz truncation issue for hg38 and grch37

### DIFF
--- a/ggd-recipes/GRCh37/gnomad_exome.yaml
+++ b/ggd-recipes/GRCh37/gnomad_exome.yaml
@@ -12,7 +12,7 @@ recipe:
         ref=../seq/GRCh37.fa
         mkdir -p variation
         export TMPDIR=`pwd`
-        vt decompose -s $url | vt normalize -r $ref -n - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
+        wget -c -O - $url | gunzip -c | vt decompose -s - | vt normalize -r $ref -n - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:

--- a/ggd-recipes/hg38/gnomad_exome.yaml
+++ b/ggd-recipes/hg38/gnomad_exome.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
         export TMPDIR=`pwd`
-        vt decompose -s $url | sed -f remap.sed | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
+        wget -c -o $url | vt decompose -s - | sed -f remap.sed | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:

--- a/ggd-recipes/hg38/gnomad_exome.yaml
+++ b/ggd-recipes/hg38/gnomad_exome.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
         export TMPDIR=`pwd`
-        wget -c -o $url | vt decompose -s - | sed -f remap.sed | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_exome.vcf.gz
         tabix -f -p vcf variation/gnomad_exome.vcf.gz
         tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
     recipe_outfiles:


### PR DESCRIPTION
Fixes https://github.com/chapmanb/cloudbiolinux/issues/281.
Uses wget to download the files as in hg19