### PR TITLE
makes sure that wget rather than vt is used to download gnomad.vcf.gz…

### DIFF
--- a/ggd-recipes/GRCh37/gnomad.yaml
+++ b/ggd-recipes/GRCh37/gnomad.yaml
@@ -12,7 +12,7 @@ recipe:
         ref=../seq/GRCh37.fa
         mkdir -p variation
         export TMPDIR=`pwd`
-        vt decompose -s $url | vt normalize -r $ref -n - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
+        wget -c -O - $url | gunzip -c | vt decompose -s - | vt normalize -r $ref -n - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
         tabix -f -p vcf variation/gnomad_genome.vcf.gz
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz

--- a/ggd-recipes/hg38/exac.yaml
+++ b/ggd-recipes/hg38/exac.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
         export TMPDIR=`pwd`
-        vt decompose -s $url | sed -f remap.sed | gsort -m 500 /dev/stdin $ref.fai | bgzip -c > variation/exac.vcf.gz
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | sed -f remap.sed | gsort -m 500 /dev/stdin $ref.fai | bgzip -c > variation/exac.vcf.gz
         tabix -f -p vcf variation/exac.vcf.gz
     recipe_outfiles:
       - variation/exac.vcf.gz

--- a/ggd-recipes/hg38/gnomad.yaml
+++ b/ggd-recipes/hg38/gnomad.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
         export TMPDIR=`pwd`
-        vt decompose -s $url | sed -f remap.sed | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | vt normalize -r $ref -n - | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/gnomad_genome.vcf.gz
         tabix -f -p vcf variation/gnomad_genome.vcf.gz
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz


### PR DESCRIPTION
… for grch37 and grch38 (and also exac.vcf.gz for grch38) to avoid potential truncation.

Similar issue was reported for gnomad_exome: https://github.com/chapmanb/cloudbiolinux/issues/281
nobody reported it yet for gnomad_genome, but truncation might happen with vt for genome as well.