### PR TITLE
Adds Topmed frequencies to grch37, hg38 and hg19.

### DIFF
--- a/config/biodata.yaml
+++ b/config/biodata.yaml
@@ -23,7 +23,7 @@ genomes:
     annotations: [GA4GH_problem_regions, capture_regions, rmsk,
                   MIG, prioritize, dbsnp, hapmap, 1000g_omni_snps, 1000g_snps,
                   mills_indels, cosmic, ancestral, clinvar, qsignature, ACMG56_genes, transcripts, RADAR, mirbase,
-                  genesplicer, effects_transcripts, vcfanno, viral, exac, gnomad_exome, esp, 1000g, varpon]
+                  genesplicer, effects_transcripts, vcfanno, viral, exac, gnomad_exome, esp, 1000g, varpon, topmed]
     annotations_available: [battenberg, dbnsfp, dbscsnv, ericscript, gnomad]
     validation: [giab-NA12878, platinum-genome-NA12878, giab-NA24385, giab-NA24631, giab-NA24143, giab-NA24149]
   - dbkey: GRCh37
@@ -32,7 +32,7 @@ genomes:
     annotations: [GA4GH_problem_regions, capture_regions,
                   MIG, prioritize, dbsnp, hapmap, 1000g_omni_snps, 1000g_snps,
                   mills_indels, cosmic, ancestral, clinvar, qsignature, ACMG56_genes, transcripts, RADAR, mirbase,
-                  genesplicer, effects_transcripts, vcfanno, viral, exac, gnomad_exome, esp, 1000g, varpon]
+                  genesplicer, effects_transcripts, vcfanno, viral, exac, gnomad_exome, esp, 1000g, varpon, topmed]
     annotations_available: [battenberg, dbnsfp, dbscsnv, ericscript, gnomad]
     validation: [giab-NA12878, giab-NA24385, giab-NA24631, dream-syn3, dream-syn4, giab-NA12878-NA24385-somatic,
                  giab-NA24143, giab-NA24149]
@@ -42,7 +42,7 @@ genomes:
     annotations: [ccds, coverage, capture_regions, rmsk, prioritize, dbsnp, hapmap_snps,
                   1000g_omni_snps, 1000g_snps, 1000g_indels,
                   mills_indels, clinvar, qsignature, ACMG56_genes, transcripts,
-                  genesplicer, effects_transcripts, vcfanno, esp, exac, gnomad_exome, viral, RADAR, mirbase, varpon]
+                  genesplicer, effects_transcripts, vcfanno, esp, exac, gnomad_exome, viral, RADAR, mirbase, varpon, topmed]
     annotations_available: [dbnsfp, dbscsnv, ericscript, gnomad]
     validation: [giab-NA12878, giab-NA24385, giab-NA24631,
                  platinum-genome-NA12878, giab-NA12878-remap, giab-NA12878-crossmap,

--- a/ggd-recipes/GRCh37/topmed.yaml
+++ b/ggd-recipes/GRCh37/topmed.yaml
@@ -1,0 +1,19 @@
+# Topmed WGS allele frequencies: https://bravo.sph.umich.edu/freeze3a/hg19/
+---
+attributes:
+  name: topmed
+  version: freeze3a
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        url=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/TOPMED_GRCh37.vcf.gz
+        ref=../seq/GRCh37.fa
+        mkdir -p variation
+        export TMPDIR=`pwd`
+        wget -c -O - $url | gunzip -c | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/topmed.vcf.gz
+        tabix -f -p vcf variation/topmed.vcf.gz
+    recipe_outfiles:
+      - variation/topmed.vcf.gz
+      - variation/topmed.vcf.gz.tbi

--- a/ggd-recipes/hg19/topmed.yaml
+++ b/ggd-recipes/hg19/topmed.yaml
@@ -1,0 +1,21 @@
+# Topmed WGS allele frequencies: https://bravo.sph.umich.edu/freeze3a/hg19/
+---
+attributes:
+  name: topmed
+  version: freeze3a
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        url=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/TOPMED_GRCh37.vcf.gz
+        remap_url=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
+        ref=../seq/hg19.fa
+        mkdir -p variation
+        export TMPDIR=`pwd`
+        wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - |  bgzip -c > variation/topmed.vcf.gz
+        tabix -f -p vcf variation/topmed.vcf.gz
+    recipe_outfiles:
+      - variation/topmed.vcf.gz
+      - variation/topmed.vcf.gz.tbi

--- a/ggd-recipes/hg38/exac.yaml
+++ b/ggd-recipes/hg38/exac.yaml
@@ -16,7 +16,7 @@ recipe:
         mkdir -p variation
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
         export TMPDIR=`pwd`
-        wget -c -O - $url | gunzip -c | sed -f remap.sed | gsort -m 500 /dev/stdin $ref.fai | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | bgzip -c > variation/exac.vcf.gz
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | grep -v "##contig=" | gsort -m 500 /dev/stdin $ref.fai | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | bgzip -c > variation/exac.vcf.gz
         tabix -f -p vcf variation/exac.vcf.gz
     recipe_outfiles:
       - variation/exac.vcf.gz

--- a/ggd-recipes/hg38/topmed.yaml
+++ b/ggd-recipes/hg38/topmed.yaml
@@ -1,0 +1,22 @@
+# Topmed WGS allele frequencies: https://bravo.sph.umich.edu/freeze5/hg38/
+# topmed vcf from ensembl does not have contig names
+---
+attributes:
+  name: topmed
+  version: freeze5
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        url=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh38/variation_genotype/TOPMED_GRCh38_20180418.vcf.gz
+        remap_url=http://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh38_ensembl2UCSC.txt
+        ref=../seq/hg38.fa
+        wget --no-check-certificate -qO- $remap_url | awk '{ print length, $0 }' | sort -n -s -r | cut -d" " -f2- | awk '{if(!$2) print "/^"$1"/d"; else if($1!=$2) print "s/^"$1"/"$2"/g";}' > remap.sed
+        mkdir -p variation
+        export TMPDIR=`pwd`
+        wget -c -O - $url | gunzip -c | sed -f remap.sed | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c > variation/topmed.vcf.gz
+        tabix -f -p vcf variation/topmed.vcf.gz
+    recipe_outfiles:
+      - variation/topmed.vcf.gz
+      - variation/topmed.vcf.gz.tbi


### PR DESCRIPTION
Please review. Topmed frequencies might be useful for variant prioritization in hg38 - native (not lifted) calls for 463 million variants on 62,784 WGS individuals.