### PR TITLE
Used bcftools annotate to remove INFO fields instead of vt rminfo,

### DIFF
--- a/doc/hacking.md
+++ b/doc/hacking.md
@@ -229,3 +229,5 @@ ln -s /path/bcbio/genomes/Hsapiens/hg38/seq seq
 export PYTHONPATH=/path/tools/cloudbiolinux:$PYTHONPATH
 python -c 'from cloudbio.biodata.ggd import install_recipe; install_recipe("/path/where_to_install", "/path/bcbio", "recipe.yaml", "hg38")'
 ```
+
+In bcbio another option is to modify the recipe in tmpbcbio-install/cloudbiolinux/ggd-recipes and rerun bcbio_nextgen.py upgrade [params].

--- a/ggd-recipes/GRCh37/gnomad.yaml
+++ b/ggd-recipes/GRCh37/gnomad.yaml
@@ -3,12 +3,12 @@
 # - https://macarthurlab.org/2018/10/17/gnomad-v2-1/
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/genomes/
 # Script 
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the reference file
+# - no need in decomposing (it is done in gnomad genome 2.1), but normalization and uniq are needed
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad
@@ -25,8 +25,8 @@ recipe:
         mkdir -p variation
         export TMPDIR=`pwd`
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt    
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
         for chrom in $(seq 1 22;echo X Y)
         do
@@ -34,11 +34,13 @@ recipe:
           vcf_url=${url_prefix}${vcf}
 
           wget -c $vcf_url
+          wget -c $vcf_url.tbi
 
-          gunzip -c $vcf | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_genome.chr${chrom}.vcf.gz
-
+          fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+          gunzip -c $vcf | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig="| bgzip -c >  variation/gnomad_genome.chr${chrom}.vcf.gz
+       
           rm $vcf
+          rm $vcf.tbi
 
           tabix variation/gnomad_genome.chr${chrom}.vcf.gz
         done
@@ -51,3 +53,4 @@ recipe:
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz
       - variation/gnomad_genome.vcf.gz.tbi
+      - variation/gnomad_genome.vcf.gz.csi

--- a/ggd-recipes/GRCh37/gnomad_exome.yaml
+++ b/ggd-recipes/GRCh37/gnomad_exome.yaml
@@ -3,12 +3,12 @@
 # - https://macarthurlab.org/2018/10/17/gnomad-v2-1/
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/
 # Script 
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the refeference file
+# - no need in decomposing, normalizing and uniq anymore - it is done in gnomad 2.1 exomes
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad_exome
@@ -24,19 +24,22 @@ recipe:
         mkdir -p variation
         export TMPDIR=`pwd`
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt    
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
+        
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
         for chrom in $(seq 1 22;echo X Y)
         do
           vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
           vcf_url=${url_prefix}${vcf}
           wget -c $vcf_url
-          gunzip -c $vcf | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_exome.chr${chrom}.vcf.gz
+          wget -c $vcf_url.tbi
 
+          fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+          gunzip -c $vcf | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | grep -v "##contig="| bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+     
           tabix variation/gnomad_exome.chr${chrom}.vcf.gz
-          rm $vcf
+          rm $vcf $vcf.tbi
         done
 
         bcftools concat variation/gnomad_exome.chr*.vcf.gz -Ov | bgzip -c > variation/gnomad_exome.vcf.gz 

--- a/ggd-recipes/hg19/gnomad.yaml
+++ b/ggd-recipes/hg19/gnomad.yaml
@@ -4,12 +4,12 @@
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/genomes/
 # Script 
 # - cleans up to use chr-style naming,
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the reference file
+# - normalizes (input is decomposed but not normalized in gnomad genome 2.1)
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad
@@ -28,21 +28,22 @@ recipe:
         export TMPDIR=`pwd`
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt    
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
-
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
+        
         for chrom in $(seq 1 22;echo X Y)
         do
           vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
           vcf_url=${url_prefix}${vcf}
 
           wget -c $vcf_url
+          wget -c $vcf_url.tbi
 
-          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | \
-          bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_genome.chr${chrom}.vcf.gz
+          fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig="| bgzip -c >  variation/gnomad_genome.chr${chrom}.vcf.gz
 
           rm $vcf
+          rm $vcf.tbi
 
           tabix variation/gnomad_genome.chr${chrom}.vcf.gz
         done
@@ -55,3 +56,4 @@ recipe:
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz
       - variation/gnomad_genome.vcf.gz.tbi
+      - variation/gnomad_genome.vcf.gz.csi

--- a/ggd-recipes/hg19/gnomad_exome.yaml
+++ b/ggd-recipes/hg19/gnomad_exome.yaml
@@ -4,12 +4,12 @@
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/
 # Script 
 # - cleans up to use chr-style naming,
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the reference file
+# - no need in decomposing, normalizing and uniq anymore - it is done in gnomad 2.1 exomes
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad_exome
@@ -28,17 +28,20 @@ recipe:
         export TMPDIR=`pwd`
         wget --no-check-certificate -qO- $remap_url | awk '{if($1!=$2) print "s/^"$1"/"$2"/g"}' > remap.sed
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt    
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
         for chrom in $(seq 1 22;echo X Y)
         do
           vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
           vcf_url=${url_prefix}${vcf}
           wget -c $vcf_url 
-          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_exome.chr${chrom}.vcf.gz
+          wget -c $vcf_url.tbi
+
+          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | grep -v "##contig="| bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+
           rm $vcf
+          rm $vcf.tbi
 
           tabix variation/gnomad_exome.chr${chrom}.vcf.gz
         done

--- a/ggd-recipes/hg38/gnomad.yaml
+++ b/ggd-recipes/hg38/gnomad.yaml
@@ -5,12 +5,12 @@
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/genomes/
 # Script 
 # - cleans up to use chr-style naming,
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the reference file
+# - normalizes (input is decomposed but not normalized in gnomad genome 2.1)
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad
@@ -30,19 +30,21 @@ recipe:
 
         export TMPDIR=`pwd`
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
         for chrom in $(seq 1 22;echo X Y)
         do
           vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
           vcf_url=${url_prefix}${vcf}
           wget -c $vcf_url
-          
-          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_genome.chr${chrom}.vcf.gz
+          wget -c $vcf_url.tbi
+
+          fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig="| bgzip -c >  variation/gnomad_genome.chr${chrom}.vcf.gz
 
           rm $vcf
+          rm $vcf.tbi
 
           tabix variation/gnomad_genome.chr${chrom}.vcf.gz
         done
@@ -55,3 +57,4 @@ recipe:
     recipe_outfiles:
       - variation/gnomad_genome.vcf.gz
       - variation/gnomad_genome.vcf.gz.tbi
+      - variation/gnomad_genome.vcf.gz.csi

--- a/ggd-recipes/hg38/gnomad_exome.yaml
+++ b/ggd-recipes/hg38/gnomad_exome.yaml
@@ -4,13 +4,12 @@
 # Lifted over to hg38 by the Ensembl variation team:
 # - http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/
 # Script 
-# - cleans up to use chr-style naming,
-# - sorts by ref file
-# - decomposes and normalizes (input is decomposed in 2.1 but not normalized)
+# - sorts according to the reference file
+# - no need in decomposing, normalizing and uniq anymore - it is done in gnomad 2.1 exomes
 # - filters only PASS variants (segdup, decoy are retained)
-# - removes many INFO fields to reduce file size: controls_, hist, non_
+# - removes many INFO fields to reduce file size: controls_, hist, non_, using bcftools annotate instead of vt rminfo, because it failed randomly on chr1
 # - merges all chr into a single file
-# wget is separated from the processing because wget in the pipe fails randomly: it comes out when downloading many files.
+# wget is separated from the processing because wget in the pipe fails randomly (on some systems?): it comes out when downloading many files.
 ---
 attributes:
   name: gnomad_exome
@@ -30,18 +29,20 @@ recipe:
 
         export TMPDIR=`pwd`
 
-        gnomad_fields_to_remove_url=https://gist.githubusercontent.com/naumenko-sa/8580e1bc91602fd67dc6331e7002dbdf/raw/ab72c1001fbbd5bed008bd3198687f687adda7f0/gnomad_fields_to_remove.txt    
-        wget --no-check-certificate -c $gnomad_fields_to_remove_url
+        gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
+        wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
         for chrom in $(seq 1 22;echo X Y)
         do
           vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
           vcf_url=${url_prefix}${vcf}
           wget -c $vcf_url 
-          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov  | \
-          vt rminfo -t $(cat gnomad_fields_to_remove.txt | paste -sd, ) - | vt decompose -s - | vt normalize -r $ref -n - | vt uniq - | grep -v "##contig=" | bgzip -c > variation/gnomad_exome.chr${chrom}.vcf.gz
+          wget -c $vcf_url.tbi
 
+          gunzip -c $vcf | sed -f remap.sed | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | grep -v "##contig="| bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+       
           rm $vcf
+          rm $vcf.tbi
 
           tabix variation/gnomad_exome.chr${chrom}.vcf.gz
         done


### PR DESCRIPTION
because the latter caused random failures for chr1 and large field list