### PR TITLE
corrected vcf concatenation order, it should be chr1, chr2, ..., chr2…

### DIFF
--- a/ggd-recipes/GRCh37/gnomad_exome.yaml
+++ b/ggd-recipes/GRCh37/gnomad_exome.yaml
@@ -24,7 +24,6 @@ recipe:
         mkdir -p variation
         export TMPDIR=`pwd`
 
-        
         gnomad_fields_to_keep_url=https://gist.githubusercontent.com/naumenko-sa/d20db928b915a87bba4012ba1b89d924/raw/cf343b105cb3347e966cc95d049e364528c86880/gnomad_fields_to_keep.txt
         wget --no-check-certificate -c $gnomad_fields_to_keep_url
 
@@ -42,11 +41,18 @@ recipe:
           rm $vcf $vcf.tbi
         done
 
-        bcftools concat variation/gnomad_exome.chr*.vcf.gz -Ov | bgzip -c > variation/gnomad_exome.vcf.gz 
-        rm variation/gnomad_exome.chr*.vcf.gz
-        rm variation/gnomad_exome.chr*.vcf.gz.tbi
-        tabix -f -p vcf variation/gnomad_exome.vcf.gz
-        tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
+        cd variation
+        bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+        gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+        gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+        gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz 
+
+        rm gnomad_exome.chr*.vcf.gz
+        rm gnomad_exome.chr*.vcf.gz.tbi
+        tabix -f -p vcf gnomad_exome.vcf.gz
+        tabix -f -p vcf --csi gnomad_exome.vcf.gz
+
+        cd ..
     recipe_outfiles:
       - variation/gnomad_exome.vcf.gz
       - variation/gnomad_exome.vcf.gz.tbi

--- a/ggd-recipes/GRCh37/grch37.gnomad_exome.merge.sh
+++ b/ggd-recipes/GRCh37/grch37.gnomad_exome.merge.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#PBS -l walltime=23:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+date
+
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+export TMPDIR=`pwd`
+cd variation
+bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz 
+
+tabix -f -p vcf gnomad_exome.vcf.gz
+tabix -f -p vcf --csi gnomad_exome.vcf.gz
+
+cd ..
+date

--- a/ggd-recipes/GRCh37/grch37.gnomad_exome.process_chr.sh
+++ b/ggd-recipes/GRCh37/grch37.gnomad_exome.process_chr.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+#PBS -l walltime=10:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+date
+
+set -eu -o pipefail
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+url_prefix=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/
+vcf_prefix=gnomad.exomes.r2.1.sites.chr
+ref=../seq/GRCh37.fa
+mkdir -p variation
+export TMPDIR=`pwd`
+
+vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
+vcf_url=${url_prefix}${vcf}
+#wget -c $vcf_url
+#wget -c $vcf_url.tbi
+
+fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+gunzip -c $vcf | gsort -m 3000 /dev/stdin $ref.fai | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | grep -v "##contig="| bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+
+tabix variation/gnomad_exome.chr${chrom}.vcf.gz
+
+date

--- a/ggd-recipes/hg19/gnomad_exome.yaml
+++ b/ggd-recipes/hg19/gnomad_exome.yaml
@@ -49,11 +49,19 @@ recipe:
           tabix variation/gnomad_exome.chr${chrom}.vcf.gz
         done
 
-        bcftools concat variation/gnomad_exome.chr*.vcf.gz -Ov | bgzip -c > variation/gnomad_exome.vcf.gz 
-        rm variation/gnomad_exome.chr*.vcf.gz
-        rm variation/gnomad_exome.chr*.vcf.gz.tbi
-        tabix -f -p vcf variation/gnomad_exome.vcf.gz
-        tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
+        cd variation
+
+        bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+        gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+        gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+        gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz
+
+        rm gnomad_exome.chr*.vcf.gz
+        rm gnomad_exome.chr*.vcf.gz.tbi
+        tabix -f -p vcf gnomad_exome.vcf.gz
+        tabix -f -p vcf --csi gnomad_exome.vcf.gz
+
+        cd ..
 
     recipe_outfiles:
       - variation/gnomad_exome.vcf.gz

--- a/ggd-recipes/hg19/hg19.gnomad_exome.merge.sh
+++ b/ggd-recipes/hg19/hg19.gnomad_exome.merge.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#PBS -l walltime=23:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+# merges per chr vcf files
+
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+export TMPDIR=`pwd`
+
+cd variation
+bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz
+
+tabix -f -p vcf variation/gnomad_exome.vcf.gz
+tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
+cd ..

--- a/ggd-recipes/hg19/hg19.gnomad_exome.process_chr.sh
+++ b/ggd-recipes/hg19/hg19.gnomad_exome.process_chr.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#PBS -l walltime=23:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+# process chr vcf file for gnomad exome
+
+set -eu -o pipefail
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+url_prefix=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh37/variation_genotype/gnomad/r2.1/exomes/
+vcf_prefix=gnomad.exomes.r2.1.sites.chr
+
+remap_url=https://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh37_ensembl2UCSC.txt
+ref=../seq/hg19.fa
+mkdir -p variation
+export TMPDIR=`pwd`
+
+vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
+vcf_url=${url_prefix}${vcf}
+#  wget -c $vcf_url 
+#  wget -c $vcf_url.tbi
+
+fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+# bcftools annotate is picky about vcf header and brakes if moved down the pipe after remap
+gunzip -c $vcf | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+
+tabix variation/gnomad_exome.chr${chrom}.vcf.gz

--- a/ggd-recipes/hg38/gnomad_exome.yaml
+++ b/ggd-recipes/hg38/gnomad_exome.yaml
@@ -50,11 +50,19 @@ recipe:
           tabix variation/gnomad_exome.chr${chrom}.vcf.gz
         done
 
-        bcftools concat variation/gnomad_exome.chr*.vcf.gz -Ov | bgzip -c > variation/gnomad_exome.vcf.gz 
-        rm variation/gnomad_exome.chr*.vcf.gz
-        rm variation/gnomad_exome.chr*.vcf.gz.tbi
-        tabix -f -p vcf variation/gnomad_exome.vcf.gz
-        tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
+        cd variation
+
+        bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+        gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+        gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+        gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz
+
+        rm gnomad_exome.chr*.vcf.gz
+        rm gnomad_exome.chr*.vcf.gz.tbi
+        tabix -f -p vcf gnomad_exome.vcf.gz
+        tabix -f -p vcf --csi gnomad_exome.vcf.gz
+
+        cd ..
     recipe_outfiles:
       - variation/gnomad_exome.vcf.gz
       - variation/gnomad_exome.vcf.gz.tbi

--- a/ggd-recipes/hg38/hg38.gnomad_exome.merge.sh
+++ b/ggd-recipes/hg38/hg38.gnomad_exome.merge.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#PBS -l walltime=10:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+date
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+export TMPDIR=`pwd`
+cd variation
+bcftools concat gnomad_exome.chr1.vcf.gz gnomad_exome.chr2.vcf.gz gnomad_exome.chr3.vcf.gz gnomad_exome.chr4.vcf.gz gnomad_exome.chr5.vcf.gz gnomad_exome.chr6.vcf.gz \
+gnomad_exome.chr7.vcf.gz gnomad_exome.chr8.vcf.gz gnomad_exome.chr9.vcf.gz gnomad_exome.chr10.vcf.gz gnomad_exome.chr11.vcf.gz gnomad_exome.chr12.vcf.gz \
+gnomad_exome.chr13.vcf.gz gnomad_exome.chr14.vcf.gz gnomad_exome.chr15.vcf.gz gnomad_exome.chr16.vcf.gz gnomad_exome.chr17.vcf.gz gnomad_exome.chr18.vcf.gz \
+gnomad_exome.chr19.vcf.gz gnomad_exome.chr20.vcf.gz gnomad_exome.chr21.vcf.gz gnomad_exome.chr22.vcf.gz gnomad_exome.chrX.vcf.gz gnomad_exome.chrY.vcf.gz -Ov | bgzip -c > gnomad_exome.vcf.gz
+
+tabix -f -p vcf variation/gnomad_exome.vcf.gz
+tabix -f -p vcf --csi variation/gnomad_exome.vcf.gz
+cd ..
+date

--- a/ggd-recipes/hg38/hg38.gnomad_exome.process_chr.sh
+++ b/ggd-recipes/hg38/hg38.gnomad_exome.process_chr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#PBS -l walltime=10:00:00,nodes=1:ppn=1
+#PBS -joe .
+#PBS -d .
+#PBS -l vmem=10g,mem=10g
+
+date
+
+set -eu -o pipefail
+export PATH=/hpf/largeprojects/ccmbio/naumenko/tools/bcbio_1.1.5/bin:$PATH
+url_prefix=http://ftp.ensemblorg.ebi.ac.uk/pub/data_files/homo_sapiens/GRCh38/variation_genotype/gnomad/r2.1/exomes/
+vcf_prefix=gnomad.exomes.r2.1.sites.grch38.chr
+
+remap_url=http://raw.githubusercontent.com/dpryan79/ChromosomeMappings/master/GRCh38_ensembl2UCSC.txt
+ref=../seq/hg38.fa
+mkdir -p variation
+
+export TMPDIR=`pwd`
+
+vcf=${vcf_prefix}${chrom}_noVEP.vcf.gz
+vcf_url=${url_prefix}${vcf}
+#wget -c $vcf_url 
+#wget -c $vcf_url.tbi
+
+fields_to_keep="INFO/"$(cat gnomad_fields_to_keep.txt | paste -s | sed s/"\t"/",INFO\/"/g)
+# bcftools annotate is picky about vcf header and brakes if moved down the pipe after remap
+gunzip -c $vcf | bcftools view -f PASS -Ov | bcftools annotate -x "^$fields_to_keep" -Ov | sed -f remap.sed | grep -v "##contig=" | gsort -m 3000 /dev/stdin $ref.fai | bgzip -c >  variation/gnomad_exome.chr${chrom}.vcf.gz
+
+tabix variation/gnomad_exome.chr${chrom}.vcf.gz
+
+date


### PR DESCRIPTION
…2, X, Y in bcftools concat

scripts on how to process gnomad2.1 exome in parallel