### PR TITLE
Add Bismark genome preparation for human genomes

### DIFF
--- a/cloudbio/biodata/galaxy.py
+++ b/cloudbio/biodata/galaxy.py
@@ -15,7 +15,8 @@ from cloudbio.custom import shared
 
 server = "rsync://datacache.g2.bx.psu.edu"
 
-index_map = {"bowtie": "bowtie_index",
+index_map = {"bismark": "bismark_index",
+             "bowtie": "bowtie_index",
              "bowtie2": "bowtie2_index",
              "bwa": "bwa_index",
              "novoalign": "novoalign_index",
@@ -108,16 +109,17 @@ def prep_locs(env, gid, indexes, config):
     """Prepare Galaxy location files for all available indexes.
     """
     for ref_index_file, cur_index, prefix, tool_name in [
-            ("sam_fa_indices.loc", indexes.get("seq", None), "", 'sam_fa_indexes'),
-            ("picard_index.loc", indexes.get("seq", None), "", "picard_indexes"),
-            ("gatk_sorted_picard_index.loc", indexes.get("seq", None), "", "gatk_picard_indexes"),
             ("alignseq.loc", indexes.get("ucsc", None), "seq", None),
-            ("twobit.loc", indexes.get("ucsc", None), "", None),
-            ("bowtie_indices.loc", indexes.get("bowtie", None), "", 'bowtie_indexes'),
+            ("bismark_indices.loc", indexes.get("bismark", None), "", 'bismark_indexes'),
             ("bowtie2_indices.loc", indexes.get("bowtie2", None), "", 'bowtie2_indexes'),
-            ("mosaik_index.loc", indexes.get("mosaik", None), "", "mosaik_indexes"),
+            ("bowtie_indices.loc", indexes.get("bowtie", None), "", 'bowtie_indexes'),
             ("bwa_index.loc", indexes.get("bwa", None), "", 'bwa_indexes'),
-            ("novoalign_indices.loc", indexes.get("novoalign", None), "", "novoalign_indexes")]:
+            ("gatk_sorted_picard_index.loc", indexes.get("seq", None), "", "gatk_picard_indexes"),
+            ("mosaik_index.loc", indexes.get("mosaik", None), "", "mosaik_indexes"),
+            ("novoalign_indices.loc", indexes.get("novoalign", None), "", "novoalign_indexes"),
+            ("picard_index.loc", indexes.get("seq", None), "", "picard_indexes"),
+            ("sam_fa_indices.loc", indexes.get("seq", None), "", 'sam_fa_indexes'),
+            ("twobit.loc", indexes.get("ucsc", None), "", None)]:
         if cur_index:
             str_parts = _build_galaxy_loc_line(env, gid, cur_index, config, prefix, tool_name)
             update_loc_file(env, ref_index_file, str_parts)

--- a/ggd-recipes/GRCh37/bismark.yaml
+++ b/ggd-recipes/GRCh37/bismark.yaml
@@ -1,0 +1,30 @@
+# Bismark genome preparation for GRCh37
+---
+attributes:
+  name: bismark
+  version: broad-20120813
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        mkdir -p bismark
+        cd bismark
+        ln -s ../seq/GRCh37.fa .
+        ln -s ../seq/GRCh37.fa.fai .
+        bismark_genome_preparation .
+    recipe_outfiles:
+      - Bisulfite_Genome/CT_conversion/BS_CT.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.2.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.3.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.4.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.2.bt2
+      - Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa
+      - Bisulfite_Genome/GA_conversion/BS_GA.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.2.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.3.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.4.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.2.bt2
+      - Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa

--- a/ggd-recipes/hg19/bismark.yaml
+++ b/ggd-recipes/hg19/bismark.yaml
@@ -1,0 +1,30 @@
+# Bismark genome preparation for hg19
+---
+attributes:
+  name: bismark
+  version: broad-20120813
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        mkdir -p bismark
+        cd bismark
+        ln -s ../seq/hg19.fa .
+        ln -s ../seq/hg19.fa.fai .
+        bismark_genome_preparation .
+    recipe_outfiles:
+      - Bisulfite_Genome/CT_conversion/BS_CT.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.2.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.3.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.4.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.2.bt2
+      - Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa
+      - Bisulfite_Genome/GA_conversion/BS_GA.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.2.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.3.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.4.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.2.bt2
+      - Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa

--- a/ggd-recipes/hg38-noalt/bismark.yaml
+++ b/ggd-recipes/hg38-noalt/bismark.yaml
@@ -1,0 +1,30 @@
+# Bismark genome preparation for GRCh38 without alternative reference contigs
+---
+attributes:
+  name: bismark
+  version: 0.1
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        mkdir -p bismark
+        cd bismark
+        ln -s ../seq/hg38-noalt.fa .
+        ln -s ../seq/hg38-noalt.fa.fai .
+        bismark_genome_preparation .
+    recipe_outfiles:
+      - Bisulfite_Genome/CT_conversion/BS_CT.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.2.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.3.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.4.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.2.bt2
+      - Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa
+      - Bisulfite_Genome/GA_conversion/BS_GA.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.2.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.3.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.4.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.2.bt2
+      - Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa

--- a/ggd-recipes/hg38/bismark.yaml
+++ b/ggd-recipes/hg38/bismark.yaml
@@ -1,0 +1,30 @@
+# Bismark genome preparation for hg38/GRCh38
+---
+attributes:
+  name: bismark
+  version: 1000g-20150219_1
+recipe:
+  full:
+    recipe_type: bash
+    recipe_cmds:
+      - |
+        mkdir -p bismark
+        cd bismark
+        ln -s ../seq/hg38.fa .
+        ln -s ../seq/hg38.fa.fai .
+        bismark_genome_preparation .
+    recipe_outfiles:
+      - Bisulfite_Genome/CT_conversion/BS_CT.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.2.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.3.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.4.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.1.bt2
+      - Bisulfite_Genome/CT_conversion/BS_CT.rev.2.bt2
+      - Bisulfite_Genome/CT_conversion/genome_mfa.CT_conversion.fa
+      - Bisulfite_Genome/GA_conversion/BS_GA.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.2.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.3.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.4.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.1.bt2
+      - Bisulfite_Genome/GA_conversion/BS_GA.rev.2.bt2
+      - Bisulfite_Genome/GA_conversion/genome_mfa.GA_conversion.fa

--- a/installed_files/tool_data_table_conf.xml
+++ b/installed_files/tool_data_table_conf.xml
@@ -1,5 +1,5 @@
 <tables>
-    <!-- Locations of MAF files that have been indexed with bx-python -->    
+    <!-- Locations of MAF files that have been indexed with bx-python -->
     <table name="indexed_maf_files">
         <columns>name, value, dbkey, species</columns>
         <file path="tool-data/maf_index.loc" />
@@ -18,6 +18,11 @@
     <table name="bowtie2_indexes" comment_char="#">
         <columns>value, dbkey, name, path</columns>
         <file path="tool-data/bowtie2_indices.loc" />
+    </table>
+    <!-- Locations of indexes in the Bismark mapper format -->
+    <table name="bismark_indexes" comment_char="#">
+        <columns>value, dbkey, name, path</columns>
+        <file path="tool-data/bismark_indices.loc" />
     </table>
     <!-- Locations of indexes in the Bowtie mapper format for TopHat to use -->
     <table name="tophat_indexes" comment_char="#">


### PR DESCRIPTION
This PR adds GGD recipes for the one-time [genome preparation](https://rawgit.com/FelixKrueger/Bismark/master/Docs/Bismark_User_Guide.html#i-bismark-genome-preparation) step required by [Bismark](https://www.bioinformatics.babraham.ac.uk/projects/bismark/) (part of `ngs_pipeline_minimal` as of PR #313).