### PR TITLE
added --clean 

### DIFF
--- a/contributors.mkd
+++ b/contributors.mkd
@@ -13,6 +13,7 @@ contribute time and expertise.
 - Mark Jensen
 - Justin Johnson
 - Ntino Krampis
+- Tristan J. Lubinski
 - Hervé Ménager
 - Dave Messina
 - Steffen Möller

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -181,9 +181,9 @@ def get_cosmic_vcf_files(genome_build, cosmic_version):
         if not clean:
             logging.info(f"{vdir} files exist, please use the --clean flag to overwrite the existing files if you want to reinstall.")
             continue
-            else:
-                logging.info(f"{vdir} exists, removing.")
-                remove_cosmic_directory(vdir)
+        else:
+            logging.info(f"{vdir} exists, removing.")
+            remove_cosmic_directory(vdir)
     logging.info("Downloading COSMIC VCF files.")
     url = "https://cancer.sanger.ac.uk/cosmic/file_download/"
     out_dir = utils.safe_makedir(os.path.join("v%s" % cosmic_version, genome_build))

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -53,7 +53,7 @@ def main(cosmic_version, bcbio_genome_dir, overwrite=False, clean=False):
                 logging.info(f"{installed_file} exists, removing.")
                 remove_installed(installed_file, installed_link)
         bcbio_ref = os.path.join(bcbio_base, "seq", f"{bcbio_build}.fa")
-        cosmic_vcf_files = get_cosmic_vcf_files(genome_build, cosmic_version)
+        cosmic_vcf_files = get_cosmic_vcf_files(genome_build, cosmic_version, clean)
         sorted_inputs = []
         for fname in cosmic_vcf_files:
             sorted_inputs.append(sort_to_ref(fname, bcbio_ref, add_chr=add_chr))
@@ -170,7 +170,7 @@ def sort_to_ref(fname, ref_file, add_chr):
     return vcfutils.bgzip_and_index(out_file, {})
 
 
-def get_cosmic_vcf_files(genome_build, cosmic_version):
+def get_cosmic_vcf_files(genome_build, cosmic_version, clean):
     """Retrieve using new authentication based download approach.
 
     GRCh38/cosmic/v85/VCF/CosmicCodingMuts.vcf.gz

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -177,7 +177,7 @@ def get_cosmic_vcf_files(genome_build, cosmic_version):
     GRCh38/cosmic/v85/VCF/CosmicNonCodingVariants.vcf.gz
     """
     vdir = os.path.join("v%s" % cosmic_version, genome_build)
-    if not os.path.exists(vdir):
+    if os.path.exists(vdir):
         if not clean:
             logging.info(f"{vdir} files exist, please use the --clean flag to overwrite the existing files if you want to reinstall.")
         else:

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -217,4 +217,4 @@ if __name__ == "__main__":
     parser.add_argument("--overwrite", action="store_true", default=False)
     parser.add_argument("--clean", action="store_true", default=False)
     args = parser.parse_args()
-    main(args.cosmic_version, args.bcbio_directory, args.overwrite)
+    main(args.cosmic_version, args.bcbio_directory, args.overwrite, args.clean)

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -180,7 +180,6 @@ def get_cosmic_vcf_files(genome_build, cosmic_version):
     if not os.path.exists(vdir):
         if not clean:
             logging.info(f"{vdir} files exist, please use the --clean flag to overwrite the existing files if you want to reinstall.")
-            continue
         else:
             logging.info(f"{vdir} exists, removing.")
             remove_cosmic_directory(vdir)

--- a/utils/prepare_cosmic.py
+++ b/utils/prepare_cosmic.py
@@ -180,7 +180,7 @@ def get_cosmic_vcf_files(genome_build, cosmic_version):
     if not os.path.exists(vdir):
         if not clean:
             logging.info(f"{vdir} files exist, please use the --clean flag to overwrite the existing files if you want to reinstall.")
-                continue
+            continue
             else:
                 logging.info(f"{vdir} exists, removing.")
                 remove_cosmic_directory(vdir)


### PR DESCRIPTION
Added `--clean` option which will remove the genome build folders and allow for a clean download of files from cosmic to the temp directory when used. Should be used in conjunction with `--overwrite` additional catch for KeyError from not having exported cosmic User/Pass on the system (friendly nudge reminder)