### PR TITLE
Pin Samtools version to 1.7

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -133,7 +133,7 @@ bio_nextgen:
   - salmon
   - sambamba
   - samblaster
-  - samtools
+  - samtools=1.7
   - scalpel
   - sentieon;env=python2
   - seq2c<2016

--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -133,7 +133,7 @@ bio_nextgen:
   - salmon
   - sambamba
   - samblaster
-  - samtools=1.7
+  - samtools=1.10
   - scalpel
   - sentieon;env=python2
   - seq2c<2016


### PR DESCRIPTION
To fix https://github.com/bcbio/bcbio-nextgen/issues/3320 and toward https://github.com/bcbio/bcbio-nextgen/issues/3318

I performed a clean bcbio install using the [latest master](https://github.com/bcbio/bcbio-nextgen/commits/c4fe472ce3b3bea282b61c505368061ba367e1a3) and ended up with the following working configuration:
```
vagrant@bcbio:~$ which samtools
/home/vagrant/local/share/bcbio/anaconda/bin/samtools
vagrant@bcbio:~$ samtools --version
samtools 1.7
Using htslib 1.7
Copyright (C) 2018 Genome Research Ltd.
vagrant@bcbio:~$ conda list openssl
# packages in environment at /home/vagrant/local/share/bcbio/anaconda:
#
# Name                    Version                   Build  Channel
openssl                   1.1.1g               h516909a_1    conda-forge
pyopenssl                 19.1.0                   py36_0    conda-forge
r-openssl                 1.4.1             r35he5c4762_0    conda-forge
vagrant@bcbio:~$ conda list samtools
# packages in environment at /home/vagrant/local/share/bcbio/anaconda:
#
# Name                    Version                   Build  Channel
bioconductor-rsamtools    1.34.0           r351hf484d3e_0    bioconda
perl-bio-samtools         1.43            pl526h1341992_1    bioconda
samtools                  1.7                           1    bioconda
```
This update will ensure this configuration is reproducible. Tested using: `bcbio_nextgen.py upgrade -u development --tools`
