### PR TITLE
rmsk: switch gzip to bgzip and add tabix

### DIFF
--- a/ggd-recipes/hg38/rmsk.yaml
+++ b/ggd-recipes/hg38/rmsk.yaml
@@ -11,6 +11,9 @@ recipe:
         mkdir -p coverage/problem_regions/repeats
         cd coverage/problem_regions/repeats
         wget  --random-wait --retry-connrefused -q -c -O rmsk.txt.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/rmsk.txt.gz
-        zcat rmsk.txt.gz | awk '{print $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' | gzip > rmsk.gtf.gz
+        zcat rmsk.txt.gz | awk '{print
+        $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' | bgzip > rmsk.gtf.gz
+        tabix rmsk.gtf.gz
     recipe_outfiles:
       - coverage/problem_regions/repeats/rmsk.gtf.gz
+      - coverage/problem_regions/repeats/rmsk.gtf.gz.tbi

--- a/ggd-recipes/hg38/rmsk.yaml
+++ b/ggd-recipes/hg38/rmsk.yaml
@@ -11,8 +11,7 @@ recipe:
         mkdir -p coverage/problem_regions/repeats
         cd coverage/problem_regions/repeats
         wget  --random-wait --retry-connrefused -q -c -O rmsk.txt.gz http://hgdownload.soe.ucsc.edu/goldenPath/hg38/database/rmsk.txt.gz
-        zcat rmsk.txt.gz | awk '{print
-        $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' | bgzip > rmsk.gtf.gz
+        zcat rmsk.txt.gz | awk '{print $6"\t.\trepeat\t"$7+1"\t"$8+1"\t.\t"$10"\t.\tname "$12";"}' | bgzip > rmsk.gtf.gz
         tabix rmsk.gtf.gz
     recipe_outfiles:
       - coverage/problem_regions/repeats/rmsk.gtf.gz


### PR DESCRIPTION
My bcbio run fails due to lack of .tbi for the rmsk.gtf.gz; this PR switches gzip to bgzip for rmsk.gtf and adds the .tbi