### PR TITLE
Replace unzip with 7z

### DIFF
--- a/ggd-recipes/hg38/dbnsfp.yaml
+++ b/ggd-recipes/hg38/dbnsfp.yaml
@@ -16,16 +16,16 @@ recipe:
         if [ ! -f dbNSFP.txt.gz ]; then
           UNPACK_DIR=`pwd`/tmpunpack
           mkdir -p $UNPACK_DIR
-          unzip dbNSFP*.zip "dbNSFP*_variant.chrM.gz"
+          7z e dbNSFP*.zip "dbNSFP*_variant.chrM.gz"
           gunzip dbNSFP*_variant.chrM.gz
           head -n1 dbNSFP*_variant.chrM > $UNPACK_DIR/header.txt
           rm dbNSFP*_variant.chrM
           # unzip only files with chromosomal info, eg. skip genes and readme.
           cat $UNPACK_DIR/header.txt > dbNSFP.txt
-          unzip -p dbNSFP*.zip "dbNSFP*_variant.chr*.gz" | gunzip -c | grep -v '^#chr' | sort -T $UNPACK_DIR -k1,1 -k2,2n >> dbNSFP.txt
+          7z e dbNSFP*.zip "dbNSFP*_variant.chr*.gz" -so | gunzip -c | grep -v '^#chr' | sort -T $UNPACK_DIR -k1,1 -k2,2n >> dbNSFP.txt
           bgzip dbNSFP.txt
           #extract readme file, used by VEP plugin to add vcf header info
-          unzip -p dbNSFP*.zip "*readme.txt" > dbNSFP.readme.txt
+          7z e dbNSFP*.zip "*readme.txt" -so > dbNSFP.readme.txt
         fi
         # index in position 1 and 2
         tabix -f -s 1 -b 2 -e 2 -c '#' dbNSFP.txt.gz


### PR DESCRIPTION
Replaced unzip with 7z in order to avoid issue during file extraction caused by unzip trying to extract dbNSFP*.zip files.

Related issues:
- https://github.com/bcbio/bcbio-nextgen/issues/913#issue-92009357
- https://github.com/bcbio/bcbio-nextgen/issues/3440#issue-813057405