### PR TITLE
Revert "remove snpeff pin"

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -149,7 +149,7 @@ bio_nextgen:
   - smcounter2;env=python2
   - smoove;env=python2
   - snap-aligner=1.0dev.97
-  - snpeff
+  - snpeff=4.3.1t
   - solvebio
   - spades
   - staden_io_lib


### PR DESCRIPTION
This reverts commit 7a497b6fdce3a457045bfdbab8ea94e4d7f4b2fe.

snpeff5.0 needs more work - databases got moved to MS