### PR TITLE
Attempt to update r-bcbiornaseq environment pinning

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -269,20 +269,8 @@ r35:
   - r=3.5.1;env=r35
   - r-base=3.5.1;env=r35
   - arriba=1.2.0;env=r35
-# to isolate rbcbiornaseq
-# htslib1.14
 rbcbiornaseq:
-  #- r>=4.1;env=rbcbiornaseq
-  #- r-base>=4.1;env=rbcbiornaseq
-  - r-basejump=0.14.23;env=rbcbiornaseq
-  - r-bcbiornaseq=0.3.44;env=rbcbiornaseq
-  - r-acidmarkdown=0.1.5;env=rbcbiornaseq
-  - r-tidyverse;env=rbcbiornaseq
-  - r-acidgenomes=0.2.20;env=rbcbiornaseq
-  - r-acidsinglecell=0.1.9;env=rbcbiornaseq
-  - r-bcbiobase=0.6.22;env=rbcbiornaseq
-  - r-acidexperiment=0.2.2;env=rbcbiornaseq
-  #- bioconductor-summarizedexperiment>=1.22.0;env=rbcbiornaseq
+  - r-bcbiornaseq=0.4.0;env=rbcbiornaseq
 # openjdk 8
 java:
   - fgbio;env=java


### PR DESCRIPTION
@naumenko-sa We should update the r-bcbiornaseq environment to the 0.4 release series. I'm working on pushing the r-bcbiornaseq 0.4.1 recipe update to bioconda, but 0.4.0 is currently available for testing within bcbio-nextgen.

The bcbioRNASeq 0.5 release series requires Bioconductor 3.15 / R 4.2, which isn't available on bioconda yet. Once Bioconductor is updated on Bioconda, I can update the r-bcbiornaseq recipe to the current stable release.