### PR TITLE
Update r-bcbiornaseq to 0.5.1

### DIFF
--- a/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
+++ b/contrib/flavor/ngs_pipeline_minimal/packages-conda.yaml
@@ -270,7 +270,7 @@ r35:
   - r-base=3.5.1;env=r35
   - arriba=1.2.0;env=r35
 rbcbiornaseq:
-  - r-bcbiornaseq=0.4.0;env=rbcbiornaseq
+  - r-bcbiornaseq>=0.5.1;env=rbcbiornaseq
 # openjdk 8
 java:
   - fgbio;env=java


### PR DESCRIPTION
The `r-bcbiornaseq` 0.5.1 update is live on bioconda (R 4.2 / Bioconductor 3.16).

See related recipe update:
https://github.com/bioconda/bioconda-recipes/pull/34651

@naumenko-sa Does this recipe update look OK?