### PR TITLE
Bump GRCh37 dbnsp to build 156

### DIFF
--- a/ggd-recipes/GRCh37/dbsnp.yaml
+++ b/ggd-recipes/GRCh37/dbsnp.yaml
@@ -3,13 +3,13 @@
 ---
 attributes:
   name: dbsnp
-  version: 154-20210112
+  version: 156-20231016
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
-        build=154
+        build=156
         version=GCF_000001405.25
         url=https://ftp.ncbi.nih.gov/snp/archive/b$build/VCF/$version.gz
         mkdir -p variation
@@ -34,6 +34,6 @@ recipe:
       - variation/dbsnp.vcf.gz
       - variation/dbsnp.vcf.gz.csi
       - variation/dbsnp.vcf.gz.tbi
-      - variation/dbsnp-154.vcf.gz
-      - variation/dbsnp-154.vcf.gz.csi
-      - variation/dbsnp-154.vcf.gz.tbi
+      - variation/dbsnp-156.vcf.gz
+      - variation/dbsnp-156.vcf.gz.csi
+      - variation/dbsnp-156.vcf.gz.tbi

--- a/ggd-recipes/hg38/dbsnp.yaml
+++ b/ggd-recipes/hg38/dbsnp.yaml
@@ -6,14 +6,14 @@
 ---
 attributes:
   name: dbsnp
-  version: 156-20230320
+  version: 156-20231017
 recipe:
   full:
     recipe_type: bash
     recipe_cmds:
       - |
         build=156
-        version=GCF_000001405.38
+        version=GCF_000001405.40
         url=http://ftp.ncbi.nih.gov/snp/archive/b$build/VCF/$version.gz
         remap_url=https://gist.githubusercontent.com/matthdsm/f833aedd2d67e28013ff1d171c70f4ee/raw/442a45ed3ddc6e85c66c5e58e0fa78e16a0821c8/refseq2ucsc.tsv
         mkdir -p variation


### PR DESCRIPTION
Fixes https://github.com/bcbio/bcbio-nextgen/issues/3714

Follows existing convention from these previous commits:

- 796932d210fe59977cbc45c7a8ede996afdc334b
- 7753ce9852f8d2f1f225187e14a5c9405d2a5b4f
- bc92cdc2009f6611aecfae689a5f8f6a78e184c4

This has not been tested, since it it somewhat cumbersome to incorporate into a local bcbio-nextgen distribution.

